### PR TITLE
feat: add dedicated marketplace flow pages

### DIFF
--- a/src/Mementic_frontend/src/App.jsx
+++ b/src/Mementic_frontend/src/App.jsx
@@ -9,6 +9,9 @@ import MyPlace from "./Pages/MyPlace";
 import Marketplace from "./Pages/Marketplace";
 import Portfolio from "./Pages/Portfolio";
 import Wallet_Page from "./Pages/Wallet";
+import PreMarketplace from "./Pages/PreMarketplace";
+import Auction from "./Pages/Auction";
+import MemeNFTPlace from "./Pages/MemeNFTPlace";
 import NotFound from "./Pages/NotFound";
 import { ToastContainer } from "./components/Toast";
 import { AuthProvider } from "./contexts/AuthContext";
@@ -42,6 +45,9 @@ function App() {
           <Route path="/landing" element={<Landing />} />
           <Route path="/myplace" element={<MyPlace />} />
           <Route path="/marketplace" element={<Marketplace />} />
+          <Route path="/pre-marketplace" element={<PreMarketplace />} />
+          <Route path="/auction" element={<Auction />} />
+          <Route path="/meme-nft" element={<MemeNFTPlace />} />
           <Route path="/portfolio" element={<Portfolio />} />
           <Route path="/wallet" element={<Wallet_Page />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/Mementic_frontend/src/Pages/Auction.jsx
+++ b/src/Mementic_frontend/src/Pages/Auction.jsx
@@ -1,0 +1,289 @@
+import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
+import {
+  Activity,
+  ArrowLeft,
+  ArrowRight,
+  Clock,
+  Gavel,
+  Sparkles,
+  Trophy,
+  Users,
+} from "lucide-react";
+import { Button } from "../components/ui/Button";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/Card";
+
+const liveAuctions = [
+  {
+    title: "Infinite HODL Spiral",
+    creator: "0x7e3…91b",
+    endsIn: "02:34:12",
+    currentBid: "245 ICP",
+    watchers: "982",
+    accent: "from-purple-500/50 to-cyan-400/40",
+  },
+  {
+    title: "Bear Market Bounceback",
+    creator: "anon.studio",
+    endsIn: "05:12:48",
+    currentBid: "118 ICP",
+    watchers: "643",
+    accent: "from-amber-400/50 to-rose-400/40",
+  },
+  {
+    title: "Diamond Hands Choir",
+    creator: "memeDAO",
+    endsIn: "08:56:03",
+    currentBid: "76 ICP",
+    watchers: "412",
+    accent: "from-emerald-400/40 to-teal-400/40",
+  },
+];
+
+const auctionPhases = [
+  {
+    title: "Open Bidding",
+    description:
+      "Creators set reserve prices while the community unlocks tiers with every new bid.",
+    icon: Gavel,
+  },
+  {
+    title: "Community Boost",
+    description:
+      "Fans stake support tokens to amplify meme visibility and unlock bonus rewards.",
+    icon: Users,
+  },
+  {
+    title: "Crown the Meme",
+    description:
+      "The final block crowns the winner and instantly distributes creator + supporter rewards.",
+    icon: Trophy,
+  },
+];
+
+const Auction = () => {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-gradient-background text-foreground">
+      <div className="pointer-events-none absolute inset-0 opacity-70">
+        <div className="hero-aurora" />
+        <div className="hero-grid" />
+        <div className="hero-sparkles" />
+      </div>
+
+      <header className="relative z-20 border-b border-border/40 bg-background/80 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-5 py-4 sm:px-8">
+          <Link
+            to="/pre-marketplace"
+            className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to pre-market flow
+          </Link>
+
+          <div className="hidden items-center gap-3 sm:flex">
+            <Link to="/meme-nft">
+              <Button variant="ghost" className="rounded-full border border-border/60 bg-background/70">
+                Mint NFTs
+              </Button>
+            </Link>
+            <Link to="/marketplace">
+              <Button variant="hero" size="lg" className="rounded-full px-6">
+                View Marketplace
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="relative z-10">
+        <section className="px-5 py-16 sm:px-8">
+          <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+              <Gavel className="h-4 w-4 text-primary" />
+              Meme Auction Arena
+            </span>
+            <h1 className="mt-6 text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
+              Real-time bidding that rewards culture shapers
+            </h1>
+            <p className="mt-6 text-lg text-muted-foreground">
+              Watch the leaderboard shift with every bid, unlock community boosts, and elevate the memes destined for legendary status.
+            </p>
+            <div className="mt-10 flex flex-col gap-4 sm:flex-row">
+              <Link to="/myplace">
+                <Button variant="hero" size="xl" className="px-10">
+                  Submit a Meme
+                </Button>
+              </Link>
+              <Link to="/pre-marketplace">
+                <Button variant="outline" size="lg" className="rounded-full border-border/60 bg-background/70">
+                  Prep in Pre-Marketplace
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="px-5 pb-16 sm:px-8">
+          <div className="mx-auto max-w-6xl">
+            <div className="grid gap-6 md:grid-cols-3">
+              {liveAuctions.map((auction, index) => (
+                <motion.div
+                  key={auction.title}
+                  custom={index}
+                  initial={{ opacity: 0, y: 24 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true, amount: 0.3 }}
+                  transition={{ delay: index * 0.1, duration: 0.45, ease: "easeOut" }}
+                  className="group overflow-hidden rounded-3xl border border-border/50 bg-background/80 p-[1px] shadow-card"
+                >
+                  <div
+                    className={`rounded-[calc(theme(borderRadius.3xl)-1px)] bg-gradient-to-br ${auction.accent} p-0.5`}
+                  >
+                    <div className="flex h-full flex-col gap-4 rounded-[calc(theme(borderRadius.3xl)-1.5px)] bg-background/95 p-6 backdrop-blur-xl">
+                      <div className="flex items-center justify-between">
+                        <span className="rounded-full border border-border/50 px-3 py-1 text-xs text-muted-foreground">
+                          Ends in {auction.endsIn}
+                        </span>
+                        <span className="inline-flex items-center gap-1 text-xs text-primary">
+                          <Clock className="h-3.5 w-3.5" />
+                          Live
+                        </span>
+                      </div>
+                      <div className="space-y-1">
+                        <h3 className="text-lg font-semibold text-foreground">{auction.title}</h3>
+                        <p className="text-sm text-muted-foreground">by {auction.creator}</p>
+                      </div>
+                      <div className="flex items-center justify-between rounded-2xl border border-border/60 bg-background/70 p-4 text-sm">
+                        <div>
+                          <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Current bid</p>
+                          <p className="mt-1 text-2xl font-semibold text-foreground">{auction.currentBid}</p>
+                        </div>
+                        <div className="text-right">
+                          <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Watchers</p>
+                          <p className="mt-1 text-lg font-semibold text-foreground">{auction.watchers}</p>
+                        </div>
+                      </div>
+                      <Link to="/meme-nft" className="inline-flex items-center gap-2 text-sm font-semibold text-primary">
+                        View drop
+                        <ArrowRight className="h-4 w-4" />
+                      </Link>
+                    </div>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="px-5 pb-16 sm:px-8">
+          <div className="mx-auto grid max-w-6xl gap-6 lg:grid-cols-2">
+            <Card className="border-border/40 bg-background/85 backdrop-blur-xl">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-muted-foreground">
+                  <Activity className="h-4 w-4 text-primary" />
+                  Live dynamics
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm text-muted-foreground">
+                <p>
+                  Bidding data updates on-chain every block. Auctions automatically extend when last-minute bids arrive, ensuring every meme gets a fair finale.
+                </p>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
+                    <p className="text-xs uppercase tracking-[0.2em]">Average APR</p>
+                    <p className="mt-2 text-2xl font-semibold text-foreground">34%</p>
+                    <span className="text-xs text-primary">Supporter staking</span>
+                  </div>
+                  <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
+                    <p className="text-xs uppercase tracking-[0.2em]">Bid velocity</p>
+                    <p className="mt-2 text-2xl font-semibold text-foreground">+276%</p>
+                    <span className="text-xs text-primary">Last 24h</span>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="border-border/40 bg-background/85 backdrop-blur-xl">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-muted-foreground">
+                  <Sparkles className="h-4 w-4 text-primary" />
+                  Auction phases
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                {auctionPhases.map((phase, index) => {
+                  const Icon = phase.icon;
+                  return (
+                    <motion.div
+                      key={phase.title}
+                      custom={index}
+                      initial={{ opacity: 0, y: 16 }}
+                      whileInView={{ opacity: 1, y: 0 }}
+                      viewport={{ once: true, amount: 0.3 }}
+                      transition={{ delay: index * 0.1, duration: 0.4, ease: "easeOut" }}
+                      className="flex items-start gap-4"
+                    >
+                      <span className="mt-1 flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-purple-500/60 to-cyan-400/50 text-white shadow-glow">
+                        <Icon className="h-5 w-5" />
+                      </span>
+                      <div className="space-y-1">
+                        <h3 className="text-base font-semibold text-foreground">{phase.title}</h3>
+                        <p className="text-sm text-muted-foreground">{phase.description}</p>
+                      </div>
+                    </motion.div>
+                  );
+                })}
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        <section className="px-5 pb-20 sm:px-8">
+          <div className="mx-auto flex max-w-5xl flex-col gap-6 rounded-3xl border border-border/40 bg-background/80 p-8 shadow-card backdrop-blur-xl sm:p-12">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <h2 className="text-2xl font-semibold text-foreground sm:text-3xl">
+                Crown your meme in the arena
+              </h2>
+              <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-1 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                <Trophy className="h-4 w-4 text-primary" />
+                Champion rewards
+              </span>
+            </div>
+
+            <p className="text-sm text-muted-foreground">
+              When the timer hits zero the smart contract distributes rewards instantly: creator royalty, supporter boosts, and collector perks for the winning bid.
+            </p>
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-col gap-2 text-sm text-muted-foreground">
+                <span className="flex items-center gap-2">
+                  <Clock className="h-4 w-4 text-primary" />
+                  Dynamic ending protection
+                </span>
+                <span className="flex items-center gap-2">
+                  <Users className="h-4 w-4 text-primary" />
+                  Supporter share multipliers
+                </span>
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Link to="/meme-nft">
+                  <Button variant="hero" className="rounded-full px-6">
+                    Mint as NFT
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Button>
+                </Link>
+                <Link to="/marketplace">
+                  <Button variant="ghost" className="rounded-full border border-border/60 bg-background/70">
+                    Explore Marketplace
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default Auction;

--- a/src/Mementic_frontend/src/Pages/Landing.jsx
+++ b/src/Mementic_frontend/src/Pages/Landing.jsx
@@ -30,19 +30,19 @@ import backendService from "../services/backendService";
 const NAV_LINKS = [
   {
     label: "Pre Meme Marketplace",
-    href: "#pre-marketplace",
+    href: "/pre-marketplace",
     icon: Store,
-    type: "anchor",
+    type: "route",
   },
   {
     label: "Meme NFT Marketplace",
-    href: "#nft-marketplace",
+    href: "/meme-nft",
     icon: ShoppingBag,
-    type: "anchor",
+    type: "route",
   },
-  { label: "Auction", href: "#auction", icon: Gavel, type: "anchor" },
+  { label: "Auction", href: "/auction", icon: Gavel, type: "route" },
   { label: "CTO", href: "#cto-guide", icon: BookOpen, type: "anchor" },
-  {label:"Guide",href:"#guide",icon:Book,type:"anchor"},
+  { label: "Guide", href: "#guide", icon: Book, type: "anchor" },
 ];
 
 const ACTION_CARDS = [
@@ -92,7 +92,13 @@ const Landing = () => {
   const { isAuthenticated, principal } = useAuth();
 
   const [menuOpen, setMenuOpen] = useState(false);
-  const [activeLink, setActiveLink] = useState("hero");
+  const [activeLink, setActiveLink] = useState(
+    location.hash
+      ? `#${location.hash.replace("#", "")}`
+      : location.pathname !== "/"
+      ? location.pathname
+      : "#hero"
+  );
   const [globalStats, setGlobalStats] = useState({ memesCreated: 12 });
   const [globalLoading, setGlobalLoading] = useState(true);
 
@@ -122,10 +128,17 @@ const Landing = () => {
 
   useEffect(() => {
     const currentHash = location.hash?.replace("#", "");
+    if (location.pathname !== "/") {
+      setActiveLink(location.pathname);
+      return;
+    }
+
     if (currentHash) {
       setActiveLink(`#${currentHash}`);
+    } else {
+      setActiveLink("#hero");
     }
-  }, [location.hash]);
+  }, [location.hash, location.pathname]);
 
   useEffect(() => {
     const anchors = navLinks
@@ -349,12 +362,7 @@ const Landing = () => {
                 variant="ghost"
                 size="lg"
                 className="rounded-full border border-border/60 bg-background/60 px-8"
-                onClick={() =>
-                  handleNav(
-                    navLinks.find((link) => link.href === "#pre-marketplace") ??
-                      navLinks[0]
-                  )
-                }
+                onClick={() => navigate("/pre-marketplace")}
               >
                 Explore Flow
               </Button>

--- a/src/Mementic_frontend/src/Pages/MemeNFTPlace.jsx
+++ b/src/Mementic_frontend/src/Pages/MemeNFTPlace.jsx
@@ -1,0 +1,241 @@
+import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
+import {
+  ArrowLeft,
+  ArrowRight,
+  BadgeCheck,
+  Flame,
+  Gem,
+  Layers,
+  ShieldCheck,
+  Sparkles,
+  Wallet,
+} from "lucide-react";
+import { Button } from "../components/ui/Button";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/Card";
+
+const utilityTiers = [
+  {
+    title: "Collector",
+    description: "Exclusive meme drops, holder chat, and remix-ready source files.",
+    perk: "+5% bid boost",
+    accent: "from-purple-500/50 to-cyan-400/40",
+  },
+  {
+    title: "Strategist",
+    description: "Stake ICP to earn royalties, access on-chain analytics, and unlock gated collabs.",
+    perk: "Royalty split",
+    accent: "from-emerald-400/40 to-teal-400/40",
+  },
+  {
+    title: "Champion",
+    description: "Lead seasonal drops, curate spotlight galleries, and co-own community vaults.",
+    perk: "Governance weight",
+    accent: "from-amber-400/40 to-rose-400/40",
+  },
+];
+
+const mintSteps = [
+  {
+    title: "Finalize metadata",
+    description: "Lock in editions, rarity traits, and unlockable files for collectors.",
+  },
+  {
+    title: "Enable staking",
+    description: "Choose if holders earn passive ICP or utility tokens via the staking vault.",
+  },
+  {
+    title: "Go live",
+    description: "Launch to the marketplace, schedule auctions, or airdrop to your loyal fans.",
+  },
+];
+
+const MemeNFTPlace = () => {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-gradient-background text-foreground">
+      <div className="pointer-events-none absolute inset-0 opacity-70">
+        <div className="hero-aurora" />
+        <div className="hero-grid" />
+        <div className="hero-sparkles" />
+      </div>
+
+      <header className="relative z-20 border-b border-border/40 bg-background/80 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-5 py-4 sm:px-8">
+          <Link
+            to="/auction"
+            className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to auctions
+          </Link>
+
+          <div className="hidden items-center gap-3 sm:flex">
+            <Link to="/marketplace">
+              <Button variant="ghost" className="rounded-full border border-border/60 bg-background/70">
+                Marketplace
+              </Button>
+            </Link>
+            <Link to="/wallet">
+              <Button variant="hero" size="lg" className="rounded-full px-6">
+                Connect Wallet
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="relative z-10">
+        <section className="px-5 py-16 sm:px-8">
+          <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+              <Sparkles className="h-4 w-4 text-primary" />
+              Meme NFT Launchpad
+            </span>
+            <h1 className="mt-6 text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
+              Ownable culture, composable utility
+            </h1>
+            <p className="mt-6 text-lg text-muted-foreground">
+              Convert your meme momentum into on-chain value. Mint verified NFTs, set up staking rewards, and reward your holders with evolving perks.
+            </p>
+            <div className="mt-10 flex flex-col gap-4 sm:flex-row">
+              <Link to="/myplace">
+                <Button variant="hero" size="xl" className="px-10">
+                  Create new drop
+                </Button>
+              </Link>
+              <Link to="/pre-marketplace">
+                <Button variant="outline" size="lg" className="rounded-full border-border/60 bg-background/70">
+                  Return to pre-market
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="px-5 pb-16 sm:px-8">
+          <div className="mx-auto grid max-w-6xl gap-6 lg:grid-cols-2">
+            <Card className="border-border/40 bg-background/85 backdrop-blur-xl">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-muted-foreground">
+                  <Layers className="h-4 w-4 text-primary" />
+                  Utility tiers
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-4 sm:grid-cols-3">
+                {utilityTiers.map((tier) => (
+                  <div
+                    key={tier.title}
+                    className={`rounded-3xl border border-border/50 bg-gradient-to-br ${tier.accent} p-[1px] shadow-card`}
+                  >
+                    <div className="flex h-full flex-col gap-3 rounded-[calc(theme(borderRadius.3xl)-1.5px)] bg-background/95 p-6 backdrop-blur-xl">
+                      <div className="flex items-center justify-between">
+                        <h3 className="text-base font-semibold text-foreground">{tier.title}</h3>
+                        <BadgeCheck className="h-4 w-4 text-primary" />
+                      </div>
+                      <p className="text-sm text-muted-foreground">{tier.description}</p>
+                      <span className="inline-flex items-center gap-2 rounded-full border border-border/50 bg-background/70 px-3 py-1 text-xs text-primary">
+                        <Gem className="h-3.5 w-3.5" />
+                        {tier.perk}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card className="border-border/40 bg-background/85 backdrop-blur-xl">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-muted-foreground">
+                  <ShieldCheck className="h-4 w-4 text-primary" />
+                  Mint checklist
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm text-muted-foreground">
+                <p>
+                  Secure, audited minting flows ensure every edition is verifiable. Tailor metadata, royalties, and whitelist access in a guided process.
+                </p>
+                <div className="space-y-3">
+                  {mintSteps.map((step, index) => (
+                    <motion.div
+                      key={step.title}
+                      initial={{ opacity: 0, x: -12 }}
+                      whileInView={{ opacity: 1, x: 0 }}
+                      viewport={{ once: true, amount: 0.4 }}
+                      transition={{ delay: index * 0.12, duration: 0.35, ease: "easeOut" }}
+                      className="flex items-start gap-3"
+                    >
+                      <span className="mt-0.5 flex h-9 w-9 items-center justify-center rounded-full border border-border/60 bg-background/70 text-xs font-semibold text-primary">
+                        {index + 1}
+                      </span>
+                      <div>
+                        <h3 className="text-sm font-semibold text-foreground">{step.title}</h3>
+                        <p>{step.description}</p>
+                      </div>
+                    </motion.div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        <section className="px-5 pb-20 sm:px-8">
+          <div className="mx-auto flex max-w-5xl flex-col gap-8 rounded-3xl border border-border/40 bg-background/80 p-8 shadow-card backdrop-blur-xl sm:p-12">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <h2 className="text-2xl font-semibold text-foreground sm:text-3xl">
+                Reward your holders forever
+              </h2>
+              <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-1 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                <Flame className="h-4 w-4 text-primary" />
+                Dynamic utility
+              </span>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="rounded-2xl border border-border/60 bg-background/70 p-6 text-sm text-muted-foreground">
+                <h3 className="text-lg font-semibold text-foreground">Holder vault</h3>
+                <p className="mt-2">
+                  Route a share of secondary sales into a vault that unlocks seasonal bonuses, merch, and real-world experiences for your top supporters.
+                </p>
+              </div>
+              <div className="rounded-2xl border border-border/60 bg-background/70 p-6 text-sm text-muted-foreground">
+                <h3 className="text-lg font-semibold text-foreground">Composable rewards</h3>
+                <p className="mt-2">
+                  Layer in quests, off-chain perks, and evolving metadata that keeps collectors engaged long after mint day.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-col gap-2 text-sm text-muted-foreground">
+                <span className="flex items-center gap-2">
+                  <Wallet className="h-4 w-4 text-primary" />
+                  Auto-withdraw royalties
+                </span>
+                <span className="flex items-center gap-2">
+                  <BadgeCheck className="h-4 w-4 text-primary" />
+                  Verified creator badge
+                </span>
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Link to="/marketplace">
+                  <Button variant="hero" className="rounded-full px-6">
+                    List collection
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Button>
+                </Link>
+                <Link to="/auction">
+                  <Button variant="ghost" className="rounded-full border border-border/60 bg-background/70">
+                    Schedule auction
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default MemeNFTPlace;

--- a/src/Mementic_frontend/src/Pages/PreMarketplace.jsx
+++ b/src/Mementic_frontend/src/Pages/PreMarketplace.jsx
@@ -1,0 +1,303 @@
+import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
+import {
+  ArrowLeft,
+  ArrowRight,
+  BarChart3,
+  CheckCircle2,
+  Flame,
+  LineChart,
+  Palette,
+  Rocket,
+  Sparkles,
+  Users,
+} from "lucide-react";
+import { Button } from "../components/ui/Button";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/Card";
+
+const featureCards = [
+  {
+    title: "AI Assisted Creation",
+    description:
+      "Use curated prompt recipes and remixable templates to build hype-worthy memes in minutes.",
+    icon: Sparkles,
+    accent: "from-purple-500/60 to-cyan-400/50",
+  },
+  {
+    title: "Momentum Tracking",
+    description:
+      "Live metrics help you understand which concepts are resonating before you mint.",
+    icon: LineChart,
+    accent: "from-cyan-400/40 to-sky-400/40",
+  },
+  {
+    title: "Creator Rooms",
+    description:
+      "Host collaborative sessions with artists, writers, and strategists to finalize the drop.",
+    icon: Users,
+    accent: "from-amber-400/40 to-rose-400/40",
+  },
+  {
+    title: "Visual Polish",
+    description:
+      "Layer filters, typography packs, and motion presets so each meme pops on the timeline.",
+    icon: Palette,
+    accent: "from-green-400/40 to-emerald-400/40",
+  },
+];
+
+const launchTimeline = [
+  {
+    title: "Concept Sprint",
+    description:
+      "Kick off with AI-assisted brainstorming, inspiration boards, and audience targeting.",
+    icon: Sparkles,
+  },
+  {
+    title: "Community Preview",
+    description:
+      "Drop teaser frames, collect emoji reactions, and gather whitelist sign-ups.",
+    icon: Users,
+  },
+  {
+    title: "Mint Ready",
+    description:
+      "Finalize metadata, rarity tiers, and staking options before hitting the marketplace.",
+    icon: Rocket,
+  },
+];
+
+const readinessChecklist = [
+  "AI prompt refined and saved",
+  "Preview frames uploaded",
+  "Community feedback loop activated",
+  "Mint contract configured",
+  "Launch schedule approved",
+];
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: (index) => ({
+    opacity: 1,
+    y: 0,
+    transition: { delay: index * 0.08, duration: 0.4, ease: "easeOut" },
+  }),
+};
+
+const PreMarketplace = () => {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-gradient-background text-foreground">
+      <div className="pointer-events-none absolute inset-0 opacity-70">
+        <div className="hero-aurora" />
+        <div className="hero-grid" />
+        <div className="hero-sparkles" />
+      </div>
+
+      <header className="relative z-20 border-b border-border/40 bg-background/80 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-5 py-4 sm:px-8">
+          <Link
+            to="/"
+            className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to landing
+          </Link>
+
+          <div className="hidden items-center gap-3 sm:flex">
+            <Link to="/auction">
+              <Button variant="ghost" className="rounded-full border border-border/60 bg-background/70">
+                Auction Hub
+              </Button>
+            </Link>
+            <Link to="/meme-nft">
+              <Button variant="hero" size="lg" className="rounded-full px-6">
+                Launch NFT Drop
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="relative z-10">
+        <section className="px-5 py-16 sm:px-8">
+          <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+              <Flame className="h-4 w-4 text-primary" />
+              Pre Meme Marketplace
+            </span>
+            <h1 className="mt-6 text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
+              Warm up your drop before it hits the main marketplace
+            </h1>
+            <p className="mt-6 text-lg text-muted-foreground">
+              Build momentum with collaborative tooling, creator analytics, and community-driven validation. The Pre Meme Marketplace is where cultural hits are born.
+            </p>
+            <div className="mt-10 flex flex-col gap-4 sm:flex-row">
+              <Link to="/myplace">
+                <Button variant="hero" size="xl" className="px-10">
+                  Start Creating
+                </Button>
+              </Link>
+              <Link to="/marketplace">
+                <Button variant="outline" size="lg" className="rounded-full border-border/60 bg-background/70">
+                  View Live Marketplace
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="px-5 pb-16 sm:px-8">
+          <div className="mx-auto max-w-6xl">
+            <div className="grid gap-6 md:grid-cols-2">
+              <Card className="border-border/40 bg-background/80 backdrop-blur-xl">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-lg font-semibold text-muted-foreground">
+                    <BarChart3 className="h-4 w-4 text-primary" />
+                    Pre-market performance
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="grid grid-cols-2 gap-4 text-sm text-muted-foreground">
+                    <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
+                      <p className="text-xs uppercase tracking-[0.2em]">Watchlist</p>
+                      <p className="mt-2 text-2xl font-semibold text-foreground">1.2k</p>
+                      <span className="text-xs text-primary">+18% this week</span>
+                    </div>
+                    <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
+                      <p className="text-xs uppercase tracking-[0.2em]">Remix saves</p>
+                      <p className="mt-2 text-2xl font-semibold text-foreground">856</p>
+                      <span className="text-xs text-primary">Trending now</span>
+                    </div>
+                  </div>
+                  <p>
+                    Spot which memes are gathering energy before they hit the auction floor. Insights update in real-time as the community reacts.
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card className="border-border/40 bg-background/80 backdrop-blur-xl">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-lg font-semibold text-muted-foreground">
+                    <Rocket className="h-4 w-4 text-primary" />
+                    Launch timeline
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  {launchTimeline.map((stage, index) => {
+                    const Icon = stage.icon;
+                    return (
+                      <motion.div
+                        key={stage.title}
+                        custom={index}
+                        initial="hidden"
+                        whileInView="visible"
+                        viewport={{ once: true, amount: 0.3 }}
+                        variants={cardVariants}
+                        className="flex items-start gap-4"
+                      >
+                        <span className="mt-1 flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-purple-500/60 to-cyan-400/50 text-white shadow-glow">
+                          <Icon className="h-5 w-5" />
+                        </span>
+                        <div className="space-y-1">
+                          <h3 className="text-base font-semibold">{stage.title}</h3>
+                          <p className="text-sm text-muted-foreground">{stage.description}</p>
+                        </div>
+                      </motion.div>
+                    );
+                  })}
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </section>
+
+        <section className="px-5 pb-16 sm:px-8">
+          <div className="mx-auto max-w-6xl">
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+              {featureCards.map((card, index) => {
+                const Icon = card.icon;
+                return (
+                  <motion.div
+                    key={card.title}
+                    custom={index}
+                    initial="hidden"
+                    whileInView="visible"
+                    viewport={{ once: true, amount: 0.2 }}
+                    variants={cardVariants}
+                    className="group overflow-hidden rounded-3xl border border-border/50 bg-background/70 p-[1px] shadow-card"
+                  >
+                    <div
+                      className={`rounded-[calc(theme(borderRadius.3xl)-1px)] bg-gradient-to-br ${card.accent} p-0.5`}
+                    >
+                      <div className="flex h-full flex-col gap-4 rounded-[calc(theme(borderRadius.3xl)-1.5px)] bg-background/95 p-6 backdrop-blur-xl">
+                        <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-purple-500/70 to-cyan-400/60 text-white shadow-glow">
+                          <Icon className="h-5 w-5" />
+                        </span>
+                        <div className="space-y-2">
+                          <h3 className="text-lg font-semibold">{card.title}</h3>
+                          <p className="text-sm text-muted-foreground">{card.description}</p>
+                        </div>
+                      </div>
+                    </div>
+                  </motion.div>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className="px-5 pb-20 sm:px-8">
+          <div className="mx-auto flex max-w-5xl flex-col gap-10 rounded-3xl border border-border/40 bg-background/80 p-8 text-sm text-muted-foreground shadow-card backdrop-blur-xl sm:p-12">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <h2 className="text-2xl font-semibold text-foreground sm:text-3xl">
+                Readiness checklist
+              </h2>
+              <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-1 text-xs font-semibold uppercase tracking-widest">
+                <CheckCircle2 className="h-4 w-4 text-primary" />
+                Launch certified
+              </span>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              {readinessChecklist.map((item) => (
+                <div
+                  key={item}
+                  className="flex items-start gap-3 rounded-2xl border border-border/60 bg-background/70 p-4"
+                >
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-primary" />
+                  <p>{item}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="flex flex-col items-start gap-4 rounded-2xl border border-dashed border-primary/40 bg-primary/5 p-6 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="text-xl font-semibold text-foreground">
+                  Ready to open the floodgates?
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  Move from concept to bids with a single click. Your audience is already waiting.
+                </p>
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Link to="/auction">
+                  <Button variant="hero" className="rounded-full px-6">
+                    Enter Auctions
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Button>
+                </Link>
+                <Link to="/meme-nft">
+                  <Button variant="ghost" className="rounded-full border border-border/60 bg-background/70">
+                    Mint NFT Collection
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default PreMarketplace;


### PR DESCRIPTION
## Summary
- add dedicated Pre Marketplace, Auction, and Meme NFT launchpad pages with immersive UI content
- wire the new pages into the app router and adjust the landing navigation to link to them
- polish the landing hero actions to route users into the updated marketplace flow

## Testing
- `npm run build` *(fails: dfx CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5105ff9b0832bb4335b091b668cd4