### PR TITLE
Switch frontend auth to Internet Identity 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,15 @@ Create a `.env` file in the `src/Mementic_frontend` directory with the following
 
 ```env
 VITE_AGENT_HOST=http://localhost:4943
-VITE_INTERNET_IDENTITY_HOST=http://rdmx6-jaaaa-aaaaa-aaadq-cai.localhost:4943 use -> https://identity.ic0.app  if deploying on mainnet
+VITE_INTERNET_IDENTITY_HOST=https://id.ai/ # override if you run your own Internet Identity instance
 VITE_II_ORIGIN=http://127.0.0.1:4943
 VITE_CANISTER_ID_MEMENTIC_BACKEND=uxrrr-q7777-77774-qaaaq-cai or use <Your-backend-Canister-ID>
 DEV = true for local else false
 ```
 
+#### Google Sign-In via Internet Identity 2.0
+
+Mementic now delegates Google authentication to [Internet Identity 2.0](https://id.ai/). No additional OAuth client configuration is required—when the login popup opens, choose the Google option inside the Internet Identity 2.0 flow. If you self-host Internet Identity or want to target a staging environment, set `VITE_INTERNET_IDENTITY_HOST` to the appropriate URL.
 
 
 Once the job completes, your application will be available at `http://localhost:4943?canisterId={asset_canister_id}`.

--- a/src/Mementic_frontend/src/Pages/Landing.jsx
+++ b/src/Mementic_frontend/src/Pages/Landing.jsx
@@ -80,16 +80,17 @@ const formatNumber = (value) => {
   }).format(numeric);
 };
 
-const formatPrincipal = (principal) => {
-  if (!principal) return "Creator";
-  if (principal.length <= 10) return principal;
-  return `${principal.slice(0, 5)}…${principal.slice(-3)}`;
+const formatDisplayName = (name, principal) => {
+  const value = name?.trim() || principal;
+  if (!value) return "Creator";
+  if (value.length <= 12) return value;
+  return `${value.slice(0, 5)}…${value.slice(-3)}`;
 };
 
 const Landing = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { isAuthenticated, principal } = useAuth();
+  const { isAuthenticated, principal, username } = useAuth();
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [activeLink, setActiveLink] = useState(
@@ -198,7 +199,7 @@ const Landing = () => {
   }, []);
 
 
-  const heroName = formatPrincipal(principal);
+  const heroName = formatDisplayName(username, principal);
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-gradient-background text-foreground">

--- a/src/Mementic_frontend/src/Pages/Login.jsx
+++ b/src/Mementic_frontend/src/Pages/Login.jsx
@@ -1,4 +1,5 @@
 import { Button } from "../components/ui/Button";
+import { Input } from "../components/ui/Input";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 import { useEffect, useState } from "react";
@@ -6,62 +7,119 @@ import { Sparkles } from "lucide-react";
 
 const Login = () => {
   const navigate = useNavigate();
-  const { login, logout, isLoading, isAuthenticated, principal, debugAuth } = useAuth();
-  const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const {
+    login,
+    logout,
+    isLoading,
+    isAuthenticated,
+    principal,
+    username,
+    updateUsername,
+    loginProvider,
+  } = useAuth();
 
-  // Redirect if already logged in
+  const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const [usernameInput, setUsernameInput] = useState("");
+  const [showUsernamePrompt, setShowUsernamePrompt] = useState(false);
+  const [usernameError, setUsernameError] = useState("");
+  const [usernameSaved, setUsernameSaved] = useState(false);
+
+  const providerName = loginProvider === "internet-identity" ? "Internet Identity 2.0" : "";
+
   useEffect(() => {
-    if (isAuthenticated && !isLoading) {
-      console.log("User already authenticated, redirecting to /myplace");
-      navigate("/myplace");
+    if (isAuthenticated) {
+      setUsernameInput(username || "");
+      setShowUsernamePrompt(!username);
+      setUsernameSaved(false);
+      setUsernameError("");
+    } else {
+      setUsernameInput("");
+      setShowUsernamePrompt(false);
+      setUsernameSaved(false);
+      setUsernameError("");
     }
-  }, [isAuthenticated, isLoading, navigate]);
+  }, [isAuthenticated, username]);
 
   const handleLogin = async () => {
-    if (isLoggingIn) return;
+    if (isLoggingIn || isLoading) {
+      return;
+    }
 
     try {
       setIsLoggingIn(true);
-      console.log("Starting login process...");
-
       const success = await login();
 
-      if (success) {
-        console.log("Login successful, will redirect via useEffect");
-      } else {
-        console.log("Login failed or was cancelled");
-        alert("Login failed or was cancelled. Please try again.");
+      if (!success) {
+        alert("Login was cancelled or failed. Try again and ensure pop-ups are allowed.");
       }
     } catch (error) {
-      console.error("Login error:", error);
-      alert("An error occurred during login. Please try again.");
+      console.error("Internet Identity login error:", error);
+      const detail = error?.message ? ` ${error.message}` : "";
+      alert(`An error occurred while connecting to Internet Identity.${detail}`);
     } finally {
       setIsLoggingIn(false);
     }
   };
-  
 
   const handleLogout = async () => {
     try {
-      console.log("Logging out...");
-      const success = await logout();
-      if (success) {
-        console.log("Logout successful");
-      }
+      await logout();
     } catch (error) {
       console.error("Logout error:", error);
     }
+    setUsernameSaved(false);
+    setShowUsernamePrompt(false);
+    setUsernameError("");
   };
 
-  // Show loading state while checking authentication
-  if (isLoading) {
+  const handleUsernameSubmit = (event) => {
+    event.preventDefault();
+    const trimmed = usernameInput.trim();
+
+    if (trimmed.length < 3) {
+      setUsernameError("Username must be at least 3 characters long.");
+      return;
+    }
+
+    if (trimmed.length > 32) {
+      setUsernameError("Username must be 32 characters or fewer.");
+      return;
+    }
+
+    updateUsername(trimmed);
+    setShowUsernamePrompt(false);
+    setUsernameSaved(true);
+    setUsernameError("");
+  };
+
+  const handleUsernameEdit = () => {
+    setShowUsernamePrompt(true);
+    setUsernameSaved(false);
+    setUsernameInput(username || "");
+    setUsernameError("");
+  };
+
+  const handleUsernameCancel = () => {
+    if (username) {
+      setShowUsernamePrompt(false);
+      setUsernameInput(username);
+    } else {
+      setUsernameInput("");
+    }
+    setUsernameError("");
+  };
+
+  const hasUsername = Boolean(username && username.trim().length > 0);
+  const continueDisabled = !hasUsername || isLoading;
+  const principalPreview = principal ? `${principal.slice(0, 6)}...${principal.slice(-4)}` : null;
+  const isAnyLoading = isLoading || isLoggingIn;
+
+  if (isLoading && !isAuthenticated) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center px-6 bg-[url('/back2.gif')] bg-cover bg-center">
         <div className="absolute inset-0 backdrop-blur-md bg-black/20"></div>
         <div className="relative z-10 text-center">
-          <div className="text-2xl text-foreground mb-4">
-            Checking authentication...
-          </div>
+          <div className="text-2xl text-foreground mb-4">Checking authentication...</div>
           <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin mx-auto"></div>
         </div>
       </div>
@@ -72,114 +130,156 @@ const Login = () => {
     <div className="min-h-screen bg-background flex items-center justify-center px-6 bg-[url('/back2.gif')] bg-cover bg-center">
       <div className="absolute inset-0 backdrop-blur-md bg-black/20"></div>
       <div className="relative z-10 max-w-md w-full text-center">
-        {/* Logo/Brand Section */}
         <div className="mb-12">
           <div className="flex items-center justify-center mb-4">
             <Sparkles className="w-16 h-16 text-primary mr-4" />
-            <h1 className="text-6xl font-black bg-gradient-hero bg-clip-text text-transparent">
-              MEMENTIC
-            </h1>
+            <h1 className="text-6xl font-black bg-gradient-hero bg-clip-text text-transparent">MEMENTIC</h1>
           </div>
-          <p className="text-xl text-muted-foreground">
-            Enter the Decentralized Meme Economy
-          </p>
+          <p className="text-xl text-muted-foreground">Enter the Decentralized Meme Economy</p>
         </div>
 
-        {/* Login Gateway */}
         <div className="bg-gradient-card border-4 border-primary p-8 rounded-xl shadow-glow">
           <div className="mb-8">
             <h2 className="text-2xl font-bold text-foreground mb-2">
-              {isAuthenticated ? "Welcome Back!" : "Welcome Creator"}
+              {isAuthenticated
+                ? hasUsername
+                  ? `Welcome back${username ? `, ${username}` : "!"}`
+                  : "Create your username"
+                : "Welcome Creator"}
             </h2>
             <p className="text-muted-foreground">
               {isAuthenticated
-                ? "You're already logged in. Continue to the app or logout."
-                : "Access your digital identity to start creating viral content"}
+                ? hasUsername
+                  ? `You're connected with ${providerName || "Internet Identity"}. Update your preferences or continue to the app.`
+                  : "Pick a username so other creators can recognize you before continuing."
+                : "Sign in with Internet Identity 2.0 to choose Google, passkeys, or your existing anchor."}
             </p>
           </div>
 
           {!isAuthenticated ? (
-            <Button
-              variant="hero"
-              size="xl"
-              className="w-full mb-6 border-2 border-purple-200 p-4 hero-button"
-              onClick={handleLogin}
-              disabled={isLoggingIn || isLoading}
-            >
-              {isLoggingIn ? (
-                <>
-                  <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2"></div>
-                  Logging in...
-                </>
-              ) : (
-                "Login with Internet Identity"
-              )}
-            </Button>
-          ) : (
             <div className="space-y-4">
               <Button
                 variant="hero"
                 size="xl"
-                className="w-full border-2 border-green-200 p-4 hero-button"
-                onClick={() => navigate("/myplace")}
+                className="w-full border-2 border-purple-200 p-4 hero-button"
+                onClick={handleLogin}
+                disabled={isAnyLoading}
               >
-                Continue to App
+                {isAnyLoading ? (
+                  <>
+                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2"></div>
+                    Connecting to Internet Identity...
+                  </>
+                ) : (
+                  "Continue with Internet Identity"
+                )}
               </Button>
-              <Button
-                variant="outline"
-                size="lg"
-                className="w-full border-2 border-red-200 p-2"
-                onClick={handleLogout}
-                disabled={isLoading}
-              >
-                {isLoading ? "Logging out..." : "Logout"}
-              </Button>
+              <div className="rounded-lg border border-white/10 bg-black/30 p-4 text-sm text-left text-muted-foreground">
+                <p className="font-semibold text-foreground">What's new in Internet Identity 2.0?</p>
+                <ul className="list-disc list-inside mt-2 space-y-1">
+                  <li>Choose Google as an authentication option at <code className="font-mono text-xs">id.ai</code>.</li>
+                  <li>Passkeys and traditional anchors continue to work side-by-side.</li>
+                  <li>No custom OAuth configuration is required in the frontend.</li>
+                </ul>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-6 text-left">
+              <div className="bg-black/20 border border-white/10 rounded-lg p-4">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-primary/80">Connected as</p>
+                    <p className="text-lg font-semibold text-foreground">{username || "No username yet"}</p>
+                  </div>
+                  <span className="text-xs font-medium px-3 py-1 rounded-full bg-white/10 text-muted-foreground">
+                    {providerName || "Internet Identity"}
+                  </span>
+                </div>
+                {principalPreview && (
+                  <p className="mt-3 text-xs text-muted-foreground break-all">Principal: {principalPreview}</p>
+                )}
+                {!hasUsername && (
+                  <p className="mt-3 text-sm text-yellow-200/80">
+                    Add a username to replace your principal across the marketplace.
+                  </p>
+                )}
+                {usernameSaved && hasUsername && (
+                  <p className="mt-3 text-xs text-emerald-300">Username saved!</p>
+                )}
+              </div>
+
+              {showUsernamePrompt || !hasUsername ? (
+                <form onSubmit={handleUsernameSubmit} className="space-y-3">
+                  <div className="text-sm text-muted-foreground">
+                    Choose a public-facing name. This will appear instead of your Internet Identity.
+                  </div>
+                  <Input
+                    value={usernameInput}
+                    onChange={(event) => setUsernameInput(event.target.value)}
+                    placeholder="Enter a username"
+                    maxLength={32}
+                    disabled={isLoading}
+                  />
+                  {usernameError && <div className="text-xs text-red-300">{usernameError}</div>}
+                  <div className="flex flex-col sm:flex-row gap-2">
+                    <Button type="submit" className="flex-1" disabled={isLoading}>
+                      Save Username
+                    </Button>
+                    {hasUsername && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="flex-1"
+                        onClick={handleUsernameCancel}
+                      >
+                        Cancel
+                      </Button>
+                    )}
+                  </div>
+                </form>
+              ) : (
+                <Button variant="ghost" className="w-full" onClick={handleUsernameEdit}>
+                  Change Username
+                </Button>
+              )}
+
+              <div className="space-y-3">
+                <Button
+                  variant="hero"
+                  size="xl"
+                  className="w-full border-2 border-green-200 p-4 hero-button"
+                  onClick={() => navigate("/myplace")}
+                  disabled={continueDisabled}
+                >
+                  {continueDisabled ? "Add a username to continue" : "Continue to App"}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="lg"
+                  className="w-full border-2 border-red-200 p-2"
+                  onClick={handleLogout}
+                  disabled={isLoading}
+                >
+                  {isLoading ? "Logging out..." : "Logout"}
+                </Button>
+              </div>
             </div>
           )}
 
-
           <div className="text-sm text-muted-foreground mt-6">
-            Secure • Decentralized • Anonymous
+            Usernames replace your principal • Secure • Decentralized
           </div>
         </div>
 
-        {/* Back to Landing Link */}
         <div className="mt-6">
           <Button
             variant="ghost"
             onClick={() => navigate("/")}
             className="text-muted-foreground hover:text-foreground"
           >
-            ← Back to Landing Page
+            ← Back to landing
           </Button>
         </div>
-
-        {/* Visual Elements */}
-        <div className="mt-12 flex justify-center space-x-4">
-          <div className="w-4 h-4 bg-primary rounded-full animate-pulse-glow"></div>
-          <div
-            className="w-4 h-4 bg-secondary rounded-full animate-pulse-glow"
-            style={{ animationDelay: "0.2s" }}
-          ></div>
-          <div
-            className="w-4 h-4 bg-accent rounded-full animate-pulse-glow"
-            style={{ animationDelay: "0.4s" }}
-          ></div>
-        </div>
-
-        {/* Debug info in development */}
-        {process.env.NODE_ENV === "development" && (
-          <div className="mt-4 p-2 bg-black/20 rounded text-xs text-muted-foreground">
-            Debug: isLoading={isLoading.toString()}, isAuthenticated=
-            {isAuthenticated.toString()}, principal={principal || "null"}
-            <button
-              onClick={() => debugAuth()}
-              className="ml-2 px-2 py-1 bg-blue-500 text-white text-xs rounded hover:bg-blue-600"
-            >
-              Debug Auth
-            </button>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/src/Mementic_frontend/src/Pages/Marketplace.jsx
+++ b/src/Mementic_frontend/src/Pages/Marketplace.jsx
@@ -368,7 +368,7 @@ function PreviewModal({
 }
 
 const Marketplace = () => {
-  const { principal, isLoading: authLoading, isAuthenticated } = useAuth();
+  const { principal, username, isLoading: authLoading, isAuthenticated } = useAuth();
   const navigate = useNavigate();
   const { toast } = useToast();
 
@@ -387,6 +387,9 @@ const Marketplace = () => {
   const [loadingTop, setLoadingTop] = useState(true);
   const [loadingList, setLoadingList] = useState(true);
   const [errorMsg, setErrorMsg] = useState("");
+
+  const currentDisplayName =
+    username?.trim() || (principal ? `${principal.slice(0, 8)}...` : "Not logged in");
 
   // Week countdown
   const [now, setNow] = useState(new Date());
@@ -985,10 +988,11 @@ const Marketplace = () => {
                     <Zap className="w-4 h-4 mr-2" />
                     Create Meme
                   </Button>
-                  <div className="text-sm text-muted-foreground hidden sm:block">
-                    {principal
-                      ? `${principal.slice(0, 8)}...`
-                      : "Not logged in"}
+                  <div
+                    className="text-sm text-muted-foreground hidden sm:block"
+                    title={username?.trim() || principal || ""}
+                  >
+                    {currentDisplayName}
                   </div>
                 </>
               ) : (

--- a/src/Mementic_frontend/src/Pages/Portfolio.jsx
+++ b/src/Mementic_frontend/src/Pages/Portfolio.jsx
@@ -78,6 +78,7 @@ const Portfolio = () => {
   const { toast } = useToast();
   const {
     principal,
+    username,
     logout,
     isAuthenticated,
     isLoading: authLoading,
@@ -88,6 +89,10 @@ const Portfolio = () => {
   const [nfts, setNfts] = useState([]);
   const [error, setError] = useState("");
   const [refreshing, setRefreshing] = useState(false);
+
+  const displayName =
+    username?.trim() || (principal ? `${principal.slice(0, 8)}...${principal.slice(-6)}` : "Not logged in");
+  const displayTitle = username?.trim() || principal || "";
 
 
   // Redirect if not authenticated
@@ -460,12 +465,10 @@ const Portfolio = () => {
               <div className="hidden sm:flex items-center gap-2 px-3 py-2 bg-muted/20 rounded-lg">
                 <User className="w-4 h-4 text-muted-foreground" />
                 <span
-                  className="text-sm font-mono text-muted-foreground"
-                  title={principal || ""}
+                  className="text-sm font-medium text-muted-foreground"
+                  title={displayTitle}
                 >
-                  {principal
-                    ? `${principal.slice(0, 8)}...${principal.slice(-6)}`
-                    : "Not logged in"}
+                  {displayName}
                 </span>
               </div>
 
@@ -524,10 +527,8 @@ const Portfolio = () => {
                 <User className="w-5 h-5 text-muted-foreground" />
                 <div>
                   <p className="text-sm font-medium">Logged in as:</p>
-                  <p className="text-xs font-mono text-muted-foreground">
-                    {principal
-                      ? `${principal.slice(0, 8)}...${principal.slice(-6)}`
-                      : "Not logged in"}
+                  <p className="text-xs text-muted-foreground" title={displayTitle}>
+                    {displayName}
                   </p>
                 </div>
               </div>

--- a/src/Mementic_frontend/src/config/environment.js
+++ b/src/Mementic_frontend/src/config/environment.js
@@ -33,13 +33,8 @@ export const getIdentityProvider = () => {
     return import.meta.env.VITE_INTERNET_IDENTITY_HOST;
   }
 
-  // For local development, use local Internet Identity canister
-  if (isDevMode()) {
-    return "http://127.0.0.1:4943/?canisterId=rdmx6-jaaaa-aaaaa-aaadq-cai";
-  }
-
-  // Use mainnet II for production
-  return "https://identity.ic0.app";
+  // Internet Identity 2.0 lives at id.ai and provides Google and passkey flows
+  return "https://id.ai/";
 };
 
 // Export canister id

--- a/src/Mementic_frontend/src/contexts/AuthContext.jsx
+++ b/src/Mementic_frontend/src/contexts/AuthContext.jsx
@@ -1,6 +1,37 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import backendService from "../services/backendService";
 
+const AUTH_STORAGE_KEY = "mementic:auth-state";
+
+const loadStoredAuthState = () => {
+  try {
+    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
+    return stored ? JSON.parse(stored) : null;
+  } catch (error) {
+    console.warn("Failed to parse stored auth state:", error);
+    return null;
+  }
+};
+
+const persistAuthState = (state) => {
+  try {
+    if (!state?.principal) {
+      localStorage.removeItem(AUTH_STORAGE_KEY);
+      return;
+    }
+
+    localStorage.setItem(
+      AUTH_STORAGE_KEY,
+      JSON.stringify({
+        provider: "internet-identity",
+        ...state,
+      })
+    );
+  } catch (error) {
+    console.warn("Failed to persist auth state:", error);
+  }
+};
+
 const AuthContext = createContext();
 
 export const useAuth = () => {
@@ -14,203 +45,188 @@ export const useAuth = () => {
 export const AuthProvider = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [user, setUser] = useState(null);
-  const [remainingCalls, setRemainingCalls] = useState(0);
   const [principal, setPrincipal] = useState(null);
+  const [remainingCalls, setRemainingCalls] = useState(0);
+  const [username, setUsername] = useState("");
 
-  // Initialize authentication on component mount
+  const loginProvider = isAuthenticated ? "internet-identity" : null;
+
   useEffect(() => {
     const initAuth = async () => {
       try {
         setIsLoading(true);
-        console.log("Initializing authentication...");
+        const storedAuth = loadStoredAuthState();
 
-        // Initialize backend service (this will create AuthClient and check for stored identity)
         await backendService.initialize();
 
-        // Check authentication state from backend service
         const isAuth = backendService.isUserAuthenticated();
-        console.log("Backend service authentication status:", isAuth);
-
         if (isAuth && backendService.authClient) {
           const identity = backendService.authClient.getIdentity();
           const principalText = identity.getPrincipal().toText();
 
           if (principalText !== "2vxsx-fae") {
-            console.log("User authenticated with principal:", principalText);
+            const storedUsername =
+              storedAuth?.principal === principalText ? storedAuth.username || "" : "";
+
             setIsAuthenticated(true);
             setPrincipal(principalText);
+            setUsername(storedUsername);
+            persistAuthState({ principal: principalText, username: storedUsername });
             await loadUserData();
-          } else {
-            console.log("Anonymous principal detected, clearing authentication state");
-            setIsAuthenticated(false);
-            setPrincipal(null);
+            return;
           }
-        } else {
-          console.log("User not authenticated or AuthClient not ready");
-          setIsAuthenticated(false);
-          setPrincipal(null);
         }
+
+        setIsAuthenticated(false);
+        setPrincipal(null);
+        setUsername("");
+        setRemainingCalls(0);
+        persistAuthState(null);
       } catch (error) {
         console.error("Failed to initialize authentication:", error);
         setIsAuthenticated(false);
         setPrincipal(null);
+        setUsername("");
+        setRemainingCalls(0);
+        persistAuthState(null);
       } finally {
         setIsLoading(false);
       }
     };
 
     initAuth();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Load user data
   const loadUserData = async () => {
     try {
       const calls = await backendService.getRemainingCalls();
       setRemainingCalls(calls);
-
-      // You can add more user data loading here
-      // const userMemes = await backendService.getUserMemes();
-      // setUser({ remainingCalls: calls, memes: userMemes });
     } catch (error) {
       console.error("Failed to load user data:", error);
     }
   };
 
-  // Login function
-  const login = async () => {
+  const loginWithInternetIdentity = async () => {
     try {
       setIsLoading(true);
-      console.log("Starting login process...");
-
       const success = await backendService.login();
 
-      if (success && backendService.authClient) {
-        console.log("Login successful, setting authenticated state");
-
-        // Small delay to ensure authentication state is fully updated
-        await new Promise(resolve => setTimeout(resolve, 100));
-
-        // Get principal directly from AuthClient
-        const identity = backendService.authClient.getIdentity();
-        const principalText = identity.getPrincipal().toText();
-
-        console.log("Identity retrieved:", identity);
-        console.log("Principal text:", principalText);
-
-        if (principalText && principalText !== "2vxsx-fae") {
-          setIsAuthenticated(true);
-          setPrincipal(principalText);
-          console.log("Principal after login:", principalText);
-          await loadUserData();
-          return true;
-        } else {
-          console.log("Login resulted in anonymous or invalid principal:", principalText);
-          setIsAuthenticated(false);
-          setPrincipal(null);
-          return false;
-        }
-      } else {
-        console.log("Login failed or AuthClient not available");
+      if (!success || !backendService.authClient) {
         setIsAuthenticated(false);
         setPrincipal(null);
+        setUsername("");
+        setRemainingCalls(0);
+        persistAuthState(null);
         return false;
       }
+
+      const identity = backendService.authClient.getIdentity();
+      const principalText = identity.getPrincipal().toText();
+
+      if (!principalText || principalText === "2vxsx-fae") {
+        setIsAuthenticated(false);
+        setPrincipal(null);
+        setUsername("");
+        setRemainingCalls(0);
+        persistAuthState(null);
+        return false;
+      }
+
+      const storedAuth = loadStoredAuthState();
+      const storedUsername =
+        storedAuth?.principal === principalText ? storedAuth.username || "" : "";
+
+      setIsAuthenticated(true);
+      setPrincipal(principalText);
+      setUsername(storedUsername);
+      persistAuthState({ principal: principalText, username: storedUsername });
+      await loadUserData();
+      return true;
     } catch (error) {
       console.error("Login failed:", error);
       setIsAuthenticated(false);
       setPrincipal(null);
+      setUsername("");
+      setRemainingCalls(0);
+      persistAuthState(null);
       throw error;
     } finally {
       setIsLoading(false);
     }
   };
 
-  // Logout function
   const logout = async () => {
     try {
       setIsLoading(true);
-      console.log("Starting logout process...");
-
       await backendService.logout();
-
-      // Force clear all authentication state
-      setIsAuthenticated(false);
-      setUser(null);
-      setRemainingCalls(0);
-      setPrincipal(null);
-
-      console.log("Logout completed successfully");
-      return true; // Return success
     } catch (error) {
       console.error("Logout failed:", error);
-      // Even if logout fails, clear the local state
-      setIsAuthenticated(false);
-      setUser(null);
-      setRemainingCalls(0);
-      setPrincipal(null);
-      return false; // Return failure
     } finally {
+      setIsAuthenticated(false);
+      setPrincipal(null);
+      setUsername("");
+      setRemainingCalls(0);
+      persistAuthState(null);
       setIsLoading(false);
+    }
+    return true;
+  };
+
+  const updateUsername = (value) => {
+    const normalized = value.trim();
+    setUsername(normalized);
+    if (principal) {
+      persistAuthState({ principal, username: normalized });
     }
   };
 
-  // Refresh user data
   const refreshUserData = async () => {
     if (isAuthenticated) {
       await loadUserData();
     }
   };
 
-  // Debug authentication state
-  const debugAuth = async () => {
-    console.log("=== AUTH CONTEXT DEBUG ===");
-    console.log("Context state:", {
+  const debugAuth = () => {
+    const backendDebug = backendService.debugAuth();
+    const context = {
       isAuthenticated,
       isLoading,
       principal,
-      remainingCalls
-    });
-
-    // Debug backend service
-    const backendDebug = backendService.debugAuth();
-    console.log("Backend service debug:", backendDebug);
-
-    console.log("=== END CONTEXT DEBUG ===");
-    return {
-      context: { isAuthenticated, isLoading, principal, remainingCalls },
-      backend: backendDebug
+      remainingCalls,
+      loginProvider,
+      username,
     };
+
+    console.log("=== AUTH CONTEXT DEBUG ===");
+    console.log("Context state:", context);
+    console.log("Backend service debug:", backendDebug);
+    console.log("=== END CONTEXT DEBUG ===");
+
+    return { context, backend: backendDebug };
   };
 
-  // Force clear authentication data (for debugging/testing)
   const forceClearAuth = async () => {
     try {
-      console.log("Force clearing authentication data...");
-
-      // Clear localStorage
       const localKeys = Object.keys(localStorage);
-      localKeys.forEach(key => {
-        if (key.includes('internet_identity') || key.includes('authClient') || key.includes('delegation')) {
+      localKeys.forEach((key) => {
+        if (key.includes("internet_identity") || key.includes("authClient") || key.includes("delegation")) {
           localStorage.removeItem(key);
         }
       });
 
-      // Clear sessionStorage
       const sessionKeys = Object.keys(sessionStorage);
-      sessionKeys.forEach(key => {
-        if (key.includes('internet_identity') || key.includes('authClient') || key.includes('delegation')) {
+      sessionKeys.forEach((key) => {
+        if (key.includes("internet_identity") || key.includes("authClient") || key.includes("delegation")) {
           sessionStorage.removeItem(key);
         }
       });
 
-      // Reset state
+      persistAuthState(null);
       setIsAuthenticated(false);
-      setUser(null);
-      setRemainingCalls(0);
       setPrincipal(null);
-
-      console.log("Authentication data cleared");
+      setUsername("");
+      setRemainingCalls(0);
       return true;
     } catch (error) {
       console.error("Failed to clear auth data:", error);
@@ -221,12 +237,15 @@ export const AuthProvider = ({ children }) => {
   const value = {
     isAuthenticated,
     isLoading,
-    user,
-    remainingCalls,
     principal,
-    login,
+    remainingCalls,
+    loginProvider,
+    username,
+    login: loginWithInternetIdentity,
+    loginWithInternetIdentity,
     logout,
     refreshUserData,
+    updateUsername,
     debugAuth,
     forceClearAuth,
     backendService,

--- a/src/Mementic_frontend/src/services/backendService.js
+++ b/src/Mementic_frontend/src/services/backendService.js
@@ -217,6 +217,36 @@ class BackendService {
     this.isAuthenticated = false;
   }
 
+  async useExternalAgent(agent) {
+    if (!agent) {
+      throw new Error("An agent instance is required to use an external identity");
+    }
+
+    if (!idlFactory || !Id) {
+      throw new Error("Backend service not properly configured");
+    }
+
+    console.log("Attaching external agent to backend service");
+    this.agent = agent;
+    this.actor = Actor.createActor(idlFactory, {
+      agent,
+      canisterId: Id,
+    });
+    this.isAuthenticated = true;
+    this.initialized = true;
+  }
+
+  async resetToAnonymous() {
+    console.log("Resetting backend service to anonymous mode");
+    this.agent = null;
+    this.actor = null;
+    this.isAuthenticated = false;
+    this.initialized = false;
+    this.authClient = null;
+    this._initPromise = null;
+    return this.initialize();
+  }
+
   /* ============ AUTHENTICATION METHODS ============ */
 
   /**


### PR DESCRIPTION
## Summary
- replace the custom Google and wallet implementations with a single Internet Identity 2.0-backed auth flow
- refresh the login experience to highlight Google availability through id.ai while keeping the username gating
- document the new default identity provider configuration and simplify the environment variables

## Testing
- npm run build *(fails: dfx not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6514557cc832bb8b0eeb3ee9dff3d