### PR TITLE
Separate NFT sale metadata from meme records

### DIFF
--- a/docs/logic_and_website_review.md
+++ b/docs/logic_and_website_review.md
@@ -1,0 +1,50 @@
+# Mementic Logic & Website Review
+
+## Executive Summary
+- **Core NFT minting works but is single-track.** Weekly winners are minted automatically through `mint_week_top3_from_voting`, which simply iterates over the leaderboard and calls `mint_to` for each meme without giving creators any say in supply size or distribution preference.【F:src/Mementic_backend/src/nft_module.rs†L441-L458】
+- **Marketplace state lives on memes, not NFTs.** Meme records capture pricing and sales statistics, whereas the NFT records only store ownership and media metadata, leaving no canonical place to track listings, provenance, or trade history on-chain.【F:src/Mementic_backend/src/http_outcall.rs†L154-L173】【F:src/Mementic_backend/src/nft_module.rs†L148-L156】
+- **Frontend surfaces a rich portfolio UI but depends on incomplete data.** The dashboard computes KPIs and renders skeletons, yet still falls back to sample rows when the backend call fails and performs per-item mint status checks that will not scale well.【F:src/Mementic_frontend/src/Pages/Portfolio.jsx†L117-L132】【F:src/Mementic_frontend/src/Pages/Portfolio.jsx†L323-L381】
+- **Infrastructure scaffolding is solid.** The frontend service class handles identity, root-key fetching, and actor creation defensively, positioning the app for both local and mainnet deployments.【F:src/Mementic_frontend/src/services/backendService.js†L20-L195】
+
+## Backend Logic Assessment
+### Strengths
+- `mint_to` fetches the meme artifact, persists the image bytes, and constructs metadata entries with MIME hints before storing the token, which is a good baseline for compliant NFT metadata.【F:src/Mementic_backend/src/nft_module.rs†L387-L435】
+- Indexes exist to prevent double minting (`MINT_INDEX`) and to answer ownership queries quickly (`OWNER_INDEX`), aligning with ICRC-7 expectations.【F:src/Mementic_backend/src/nft_module.rs†L188-L283】
+- Marketplace helpers already guard listing updates with ownership checks and maintain aggregate counters such as views and total earned at the meme level, which keeps essential economics on-chain.【F:src/Mementic_backend/src/http_outcall.rs†L154-L173】【F:src/Mementic_backend/src/http_outcall.rs†L500-L519】
+
+### Gaps & Risks
+- **No mint-style preference.** Weekly minting always issues a single edition; there is no API for winners to request “collection” vs “1/1,” and the mint logic has no concept of remaining supply or delayed distribution.【F:src/Mementic_backend/src/nft_module.rs†L441-L458】
+- **Token records lack sale metadata.** `TokenRecord` omits fields for list price, sale state, previous owners, or royalty configuration, so provenance cannot be reconstructed solely from NFT data.【F:src/Mementic_backend/src/nft_module.rs†L148-L156】
+- **Ownership index is append-only.** `push_owner` only ever pushes new IDs; without a corresponding removal routine, secondary transfers would leave stale ownership references and double-count holdings.【F:src/Mementic_backend/src/nft_module.rs†L307-L313】
+- **Global discovery endpoints are missing.** The NFT module exposes `icrc7_tokens_of` and `get_token`, but there is no pagination-friendly list of all tokens or richer owner views that join meme metadata, making marketplace browsing hard to implement.【F:src/Mementic_backend/src/nft_module.rs†L259-L289】
+- **Listings tied to memes, not tokens.** Because listing information is stored on `StoredMeme`, selling an NFT independently of its original meme data is not possible, complicating secondary-market mechanics.【F:src/Mementic_backend/src/http_outcall.rs†L154-L173】【F:src/Mementic_backend/src/http_outcall.rs†L500-L519】
+
+### Suggested Next Steps
+1. Introduce a mint preference store keyed by meme/creator and branch `mint_to` so it can either mint a unique token or set up a multi-edition drop with supply tracking.
+2. Extend `TokenRecord` with sale state, price, royalty, and provenance fields, and add transfer/listing updates that keep `OWNER_INDEX` in sync.
+3. Add query endpoints that return enriched NFT DTOs (owner, meme metadata, sale info) for both “all tokens” and “tokens of principal,” plus simple pagination filters.
+4. Migrate marketplace state from `StoredMeme` into NFT-centric records so trades and listings are governed by the token rather than mutable meme state.
+
+## Frontend & UX Assessment
+### Strengths
+- The portfolio view derives multiple KPIs (votes, earnings, mint/list ratios) from the fetched array, supporting the metrics-driven experience you described.【F:src/Mementic_frontend/src/Pages/Portfolio.jsx†L117-L132】
+- Skeleton components provide a polished loading experience while data is fetched, which helps mask latency and keeps the UI responsive.【F:src/Mementic_frontend/src/Pages/Portfolio.jsx†L45-L76】
+- Username editing flows, toast feedback, and authentication guards show attention to creator onboarding and account management UX.【F:src/Mementic_frontend/src/Pages/Portfolio.jsx†L167-L252】
+- The backend service centralizes all canister interactions, including identity bootstrapping, anonymous fallbacks, and per-call safety wrappers, giving the UI a consistent API layer.【F:src/Mementic_frontend/src/services/backendService.js†L20-L195】【F:src/Mementic_frontend/src/services/backendService.js†L522-L612】
+
+### Gaps & Risks
+- **Sample data fallback.** When `getUserMemes` fails, the portfolio injects placeholder memes, which can mask production issues and distort analytics unless clearly labeled as mock data.【F:src/Mementic_frontend/src/Pages/Portfolio.jsx†L323-L357】
+- **Mint status fan-out.** `fetchData` calls `is_meme_minted` sequentially for every meme (with artificial delays), which increases round trips and will become a bottleneck as portfolios grow.【F:src/Mementic_frontend/src/Pages/Portfolio.jsx†L365-L378】
+- **Listing actions tied to memes.** The UI calls `listMemeForSale` against meme IDs, reflecting the backend constraint that sales operate on memes, not NFTs; this will need to change once tokens track listings themselves.【F:src/Mementic_frontend/src/Pages/Portfolio.jsx†L134-L152】【F:src/Mementic_frontend/src/services/backendService.js†L573-L590】
+- **Metrics rely on local derivation.** Without backend aggregation (e.g., total revenue, collection supply mix), the dashboard only reflects the currently loaded items and cannot show platform-wide stats you mentioned wanting on the homepage.
+
+### Suggested Next Steps
+1. Replace placeholder data with explicit error states or guided troubleshooting, and surface when data is mock vs live to avoid confusion.
+2. Batch mint-status checks by adding a backend endpoint that returns mint flags for multiple meme IDs at once; this will keep the UI snappy as creators accumulate content.
+3. Once NFT-centric listings exist, update the portfolio to work with token IDs and expose the choice between “keep unique” vs “launch collection” directly in the UI flow for weekly winners.
+4. Add backend analytics endpoints (e.g., total NFTs, total volume, floor price, collection vs unique counts) so the frontend metrics can mirror the insights you want to showcase.
+
+ Additional Opportunities
+ Add provenance or event logs that the frontend can visualize as a timeline, helping collectors understand meme history once secondary trades are enabled. Provide filters and sorting on the marketplace page backed by new query parameters (e.g., listed only, price range, mint style) to make discovery easier.
+- Consider integrating royalties and automated payouts, since weekly winners and contributors may expect recurring revenue from downstream sales.
+Overall, the architecture lays a strong foundation—AI generation, meme storage, and initial NFT minting all work end-to-end—but broadening the NFT data model and exposing richer queries will unlock the marketplace behaviors and analytics you’re aiming for.

--- a/src/Mementic_backend/Mementic_backend.did
+++ b/src/Mementic_backend/Mementic_backend.did
@@ -28,16 +28,6 @@ type LeaderboardEntry = record {
   rank : nat32;
   meme_data : opt PublicStoredMeme;
 };
-type MarketData = record {
-  listing_price : opt nat64;
-  total_sales : nat64;
-  last_sale_price : opt nat64;
-  views : nat64;
-  is_listed : bool;
-  last_sale_at : opt nat64;
-  total_earned : nat64;
-  listed_at : opt nat64;
-};
 type MemeData = record {
   image_url : text;
   metadata : PythonMetadata;
@@ -66,10 +56,11 @@ type NftImage = record { mime_type : text; image : blob };
 type PublicStoredMeme = record {
   id : nat64;
   owner : principal;
-  market_data : MarketData;
   created_at : nat64;
   meme_data : MemeData;
   canister_timestamp : nat64;
+  views : nat64;
+  sale_metadata : opt TokenSaleMetadata;
 };
 type PythonMetadata = record {
   "service" : text;
@@ -99,6 +90,17 @@ type TokenRecord = record {
   mime_type : opt text;
   has_image : bool;
   minted_at : nat64;
+};
+type TokenSaleMetadata = record {
+  token_id : nat;
+  meme_id : nat64;
+  is_listed : bool;
+  listing_price : opt nat64;
+  listed_at : opt nat64;
+  total_sales : nat64;
+  total_earned : nat64;
+  last_sale_price : opt nat64;
+  last_sale_at : opt nat64;
 };
 type TopEntry = record {
   upvotes : nat32;
@@ -176,6 +178,8 @@ service : (opt InitArgs) -> {
   get_nft_image : (nat) -> (opt NftImage) query;
   get_token : (nat) -> (opt TokenRecord) query;
   get_token_by_meme_id : (nat64) -> (opt nat) query;
+  get_sale_metadata : (nat) -> (opt TokenSaleMetadata) query;
+  get_sale_metadata_for_meme : (nat64) -> (opt TokenSaleMetadata) query;
   // Return **Top 3** for a given week (for NFT mint step).
   // Fails if the week is not completed yet.
   get_top3_for_week : (nat64) -> (Result_3) query;

--- a/src/Mementic_backend/src/http_outcall.rs
+++ b/src/Mementic_backend/src/http_outcall.rs
@@ -2,11 +2,11 @@
 #![allow(clippy::too_many_arguments)]
 
 use candid::{CandidType, Nat, Principal};
-use ic_cdk::{caller,api::time};
 use ic_cdk::api::management_canister::http_request::{
     http_request, CanisterHttpRequestArgument, HttpHeader, HttpMethod, HttpResponse, TransformArgs,
     TransformContext,
 };
+use ic_cdk::{api::time, caller};
 
 use ic_cdk_macros::{query, update};
 use ic_stable_structures::{
@@ -17,6 +17,7 @@ use ic_stable_structures::{
 use ic_cdk::api::call::call;
 use ic_cdk::api::call::call_with_payment;
 
+use crate::nft_module::TokenSaleMetadata;
 use ic_stable_structures::storable::Bound;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -34,23 +35,46 @@ const MEME_WORKER_URL: &str = "https://dark-shape-faac.h28177922.workers.dev/gen
 pub struct StorablePrincipal(Principal);
 
 impl Storable for StorablePrincipal {
-    const BOUND: Bound = Bound::Bounded { max_size: 29, is_fixed_size: false };
-    fn to_bytes(&self) -> Cow<[u8]> { Cow::Borrowed(self.0.as_slice()) }
-    fn into_bytes(self) -> Vec<u8> { self.0.as_slice().to_vec() }
-    fn from_bytes(bytes: Cow<[u8]>) -> Self { StorablePrincipal(Principal::from_slice(bytes.as_ref())) }
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 29,
+        is_fixed_size: false,
+    };
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(self.0.as_slice())
+    }
+    fn into_bytes(self) -> Vec<u8> {
+        self.0.as_slice().to_vec()
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        StorablePrincipal(Principal::from_slice(bytes.as_ref()))
+    }
 }
-impl From<Principal> for StorablePrincipal { fn from(p: Principal) -> Self { StorablePrincipal(p) } }
-impl From<StorablePrincipal> for Principal { fn from(sp: StorablePrincipal) -> Self { sp.0 } }
+impl From<Principal> for StorablePrincipal {
+    fn from(p: Principal) -> Self {
+        StorablePrincipal(p)
+    }
+}
+impl From<StorablePrincipal> for Principal {
+    fn from(sp: StorablePrincipal) -> Self {
+        sp.0
+    }
+}
 
 // ---------- Storable wrapper for Vec<u64> ----------
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct StorableVecU64(pub Vec<u64>);
 impl StorableVecU64 {
     pub const MAX_LEN: usize = 1024;
-    #[inline] fn byte_capacity_for(len: usize) -> usize { 4 + 8 * len }
+    #[inline]
+    fn byte_capacity_for(len: usize) -> usize {
+        4 + 8 * len
+    }
 }
 impl Storable for StorableVecU64 {
-    const BOUND: Bound = Bound::Bounded { max_size: (4 + 8 * Self::MAX_LEN) as u32, is_fixed_size: false };
+    const BOUND: Bound = Bound::Bounded {
+        max_size: (4 + 8 * Self::MAX_LEN) as u32,
+        is_fixed_size: false,
+    };
     fn to_bytes(&self) -> Cow<[u8]> {
         let mut len = self.0.len().min(Self::MAX_LEN);
         let mut bytes = Vec::with_capacity(Self::byte_capacity_for(len));
@@ -71,13 +95,17 @@ impl Storable for StorableVecU64 {
     }
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         let b = bytes.as_ref();
-        if b.len() < 4 { return StorableVecU64(Vec::new()); }
+        if b.len() < 4 {
+            return StorableVecU64(Vec::new());
+        }
         let declared = u32::from_le_bytes([b[0], b[1], b[2], b[3]]) as usize;
         let len = declared.min(Self::MAX_LEN);
         let mut v = Vec::with_capacity(len);
         for i in 0..len {
             let start = 4 + i * 8;
-            if start + 8 > b.len() { break; }
+            if start + 8 > b.len() {
+                break;
+            }
             let mut arr = [0u8; 8];
             arr.copy_from_slice(&b[start..start + 8]);
             v.push(u64::from_le_bytes(arr));
@@ -85,8 +113,16 @@ impl Storable for StorableVecU64 {
         StorableVecU64(v)
     }
 }
-impl From<Vec<u64>> for StorableVecU64 { fn from(v: Vec<u64>) -> Self { StorableVecU64(v) } }
-impl From<StorableVecU64> for Vec<u64> { fn from(sv: StorableVecU64) -> Self { sv.0 } }
+impl From<Vec<u64>> for StorableVecU64 {
+    fn from(v: Vec<u64>) -> Self {
+        StorableVecU64(v)
+    }
+}
+impl From<StorableVecU64> for Vec<u64> {
+    fn from(sv: StorableVecU64) -> Self {
+        sv.0
+    }
+}
 
 // ---------- Stable memory setup ----------
 thread_local! {
@@ -112,9 +148,15 @@ thread_local! {
 
 // ---------- Data structures ----------
 #[derive(Clone, Debug, Default, Serialize, Deserialize, CandidType)]
-struct DayUsage { day: u64, count: u8 }
+struct DayUsage {
+    day: u64,
+    count: u8,
+}
 impl Storable for DayUsage {
-    const BOUND: Bound = Bound::Bounded { max_size: 9, is_fixed_size: true };
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 9,
+        is_fixed_size: true,
+    };
     fn to_bytes(&self) -> Cow<[u8]> {
         let mut bytes = Vec::with_capacity(9);
         bytes.extend_from_slice(&self.day.to_le_bytes());
@@ -128,10 +170,15 @@ impl Storable for DayUsage {
         bytes
     }
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        if bytes.len() != 9 { return DayUsage::default(); }
+        if bytes.len() != 9 {
+            return DayUsage::default();
+        }
         let mut day_arr = [0u8; 8];
         day_arr.copy_from_slice(&bytes[0..8]);
-        DayUsage { day: u64::from_le_bytes(day_arr), count: bytes[8] }
+        DayUsage {
+            day: u64::from_le_bytes(day_arr),
+            count: bytes[8],
+        }
     }
 }
 
@@ -153,29 +200,23 @@ pub struct PythonMetadata {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, CandidType)]
-pub struct MarketData {
-    pub is_listed: bool,
-    pub listing_price: Option<u64>, // Price in e8s (ICP smallest unit)
-    pub listed_at: Option<u64>,
-    pub total_sales: u64,
-    pub total_earned: u64, // Total earned from sales in e8s
-    pub last_sale_price: Option<u64>,
-    pub last_sale_at: Option<u64>,
-    pub views: u64, // Number of times this meme has been viewed
-}
-#[derive(Clone, Debug, Serialize, Deserialize, CandidType)]
 pub struct StoredMeme {
     pub id: u64,
     pub owner: StorablePrincipal,
     pub meme_data: MemeData,
     pub created_at: u64,
     pub canister_timestamp: u64,
-    pub market_data: MarketData,
+    #[serde(default)]
+    pub views: u64,
 }
 impl Storable for StoredMeme {
     const BOUND: Bound = Bound::Unbounded;
-    fn to_bytes(&self) -> Cow<[u8]> { Cow::Owned(serde_json::to_vec(self).unwrap_or_default()) }
-    fn into_bytes(self) -> Vec<u8> { serde_json::to_vec(&self).unwrap_or_default() }
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(serde_json::to_vec(self).unwrap_or_default())
+    }
+    fn into_bytes(self) -> Vec<u8> {
+        serde_json::to_vec(&self).unwrap_or_default()
+    }
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         serde_json::from_slice(bytes.as_ref()).unwrap_or_else(|_| StoredMeme {
             id: 0,
@@ -186,20 +227,16 @@ impl Storable for StoredMeme {
                 image_url: String::new(),
                 image_filename: String::new(),
                 image_format: String::new(),
-                metadata: PythonMetadata { processing_time: 0.0, timestamp: 0, file_size_bytes: 0, service: String::new() },
+                metadata: PythonMetadata {
+                    processing_time: 0.0,
+                    timestamp: 0,
+                    file_size_bytes: 0,
+                    service: String::new(),
+                },
             },
             created_at: 0,
             canister_timestamp: 0,
-            market_data: MarketData {
-                is_listed: false,
-                listing_price: None,
-                listed_at: None,
-                total_sales: 0,
-                total_earned: 0,
-                last_sale_price: None,
-                last_sale_at: None,
-                views: 0,
-            },
+            views: 0,
         })
     }
 }
@@ -210,7 +247,8 @@ pub struct PublicStoredMeme {
     pub meme_data: MemeData,
     pub created_at: u64,
     pub canister_timestamp: u64,
-    pub market_data: MarketData,
+    pub views: u64,
+    pub sale_metadata: Option<TokenSaleMetadata>,
 }
 impl From<StoredMeme> for PublicStoredMeme {
     fn from(sm: StoredMeme) -> Self {
@@ -220,21 +258,27 @@ impl From<StoredMeme> for PublicStoredMeme {
             meme_data: sm.meme_data,
             created_at: sm.created_at,
             canister_timestamp: sm.canister_timestamp,
-            market_data: sm.market_data,
+            views: sm.views,
+            sale_metadata: crate::nft_module::get_sale_metadata_for_meme(sm.id),
         }
     }
 }
 
 // ---------- Helpers ----------
 fn is_url_allowed(url: &str) -> bool {
-    url.starts_with("https://") || url.starts_with("http://127.0.0.1") || url.starts_with("http://localhost")
+    url.starts_with("https://")
+        || url.starts_with("http://127.0.0.1")
+        || url.starts_with("http://localhost")
 }
 fn url_encode(input: &str) -> String {
-    input.chars().map(|c| match c {
-        'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => c.to_string(),
-        ' ' => "%20".to_string(),
-        _ => format!("%{:02X}", c as u8),
-    }).collect()
+    input
+        .chars()
+        .map(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => c.to_string(),
+            ' ' => "%20".to_string(),
+            _ => format!("%{:02X}", c as u8),
+        })
+        .collect()
 }
 
 // ---------- Simple GET helper (Cloudflare Worker) ----------
@@ -258,7 +302,7 @@ pub async fn generate_meme(prompt: String) -> Result<String, String> {
     let storable_user = StorablePrincipal::from(user);
     let now = time();
     let current_day = now / (24 * 60 * 60 * 1_000_000_000); // Convert ns to days
-    
+
     // Check if user has exceeded daily limit
     let can_generate = RATE.with(|r| {
         let mut rate_map = r.borrow_mut();
@@ -275,7 +319,7 @@ pub async fn generate_meme(prompt: String) -> Result<String, String> {
             true
         }
     });
-    
+
     if !can_generate {
         return Err("Daily meme generation limit reached. Please try again tomorrow.".to_string());
     }
@@ -288,8 +332,14 @@ pub async fn generate_meme(prompt: String) -> Result<String, String> {
     }
 
     let headers = vec![
-        HttpHeader { name: "User-Agent".into(), value: "mementic_canister".into() },
-        HttpHeader { name: "Accept".into(), value: "application/json".into() },
+        HttpHeader {
+            name: "User-Agent".into(),
+            value: "mementic_canister".into(),
+        },
+        HttpHeader {
+            name: "Accept".into(),
+            value: "application/json".into(),
+        },
     ];
 
     let req = CanisterHttpRequestArgument {
@@ -320,15 +370,28 @@ pub async fn generate_meme(prompt: String) -> Result<String, String> {
                 rate_map.insert(storable_user, new_usage);
             } else {
                 // New day, reset count to 1
-                rate_map.insert(storable_user, DayUsage { day: current_day, count: 1 });
+                rate_map.insert(
+                    storable_user,
+                    DayUsage {
+                        day: current_day,
+                        count: 1,
+                    },
+                );
             }
         } else {
             // First time user, start with count 1
-            rate_map.insert(storable_user, DayUsage { day: current_day, count: 1 });
+            rate_map.insert(
+                storable_user,
+                DayUsage {
+                    day: current_day,
+                    count: 1,
+                },
+            );
         }
     });
 
-    let response_text = String::from_utf8(resp.body).unwrap_or_else(|_| "<non-utf8-body>".to_string());
+    let response_text =
+        String::from_utf8(resp.body).unwrap_or_else(|_| "<non-utf8-body>".to_string());
     ic_cdk::println!("Cloudflare Worker Response: {}", &response_text);
 
     // Parse the response to extract meme data
@@ -342,22 +405,26 @@ pub async fn generate_meme(prompt: String) -> Result<String, String> {
                 ic_cdk::println!("Found nested 'data' object, extracting meme data from it");
 
                 // Extract fields from the data object
-                let prompt = data_obj.get("prompt")
+                let prompt = data_obj
+                    .get("prompt")
                     .and_then(|v| v.as_str())
                     .unwrap_or(&prompt)
                     .to_string();
 
-                let image_url = data_obj.get("image_url")
+                let image_url = data_obj
+                    .get("image_url")
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
 
-                let image_filename = data_obj.get("image_filename")
+                let image_filename = data_obj
+                    .get("image_filename")
                     .and_then(|v| v.as_str())
                     .unwrap_or("generated_meme.png")
                     .to_string();
 
-                let image_format = data_obj.get("image_format")
+                let image_format = data_obj
+                    .get("image_format")
                     .and_then(|v| v.as_str())
                     .unwrap_or("png")
                     .to_string();
@@ -366,16 +433,20 @@ pub async fn generate_meme(prompt: String) -> Result<String, String> {
                 let metadata_obj = data_obj.get("metadata");
                 let metadata = if let Some(meta) = metadata_obj {
                     PythonMetadata {
-                        processing_time: meta.get("processing_time")
+                        processing_time: meta
+                            .get("processing_time")
                             .and_then(|v| v.as_f64())
                             .unwrap_or(1.0),
-                        timestamp: meta.get("timestamp")
+                        timestamp: meta
+                            .get("timestamp")
                             .and_then(|v| v.as_u64())
                             .unwrap_or(time()),
-                        file_size_bytes: meta.get("file_size_bytes")
+                        file_size_bytes: meta
+                            .get("file_size_bytes")
                             .and_then(|v| v.as_u64())
                             .unwrap_or(1024000),
-                        service: meta.get("service")
+                        service: meta
+                            .get("service")
                             .and_then(|v| v.as_str())
                             .unwrap_or("icp-meme-generator")
                             .to_string(),
@@ -410,42 +481,50 @@ pub async fn generate_meme(prompt: String) -> Result<String, String> {
                         ic_cdk::println!("Response was: {}", &response_text);
 
                         // Last resort: extract fields from root level
-                        let prompt = json_value.get("prompt")
+                        let prompt = json_value
+                            .get("prompt")
                             .and_then(|v| v.as_str())
                             .unwrap_or(&prompt)
                             .to_string();
 
-                        let image_url = json_value.get("image_url")
+                        let image_url = json_value
+                            .get("image_url")
                             .or_else(|| json_value.get("url"))
                             .or_else(|| json_value.get("image"))
                             .and_then(|v| v.as_str())
                             .unwrap_or("")
                             .to_string();
 
-                        let image_filename = json_value.get("image_filename")
+                        let image_filename = json_value
+                            .get("image_filename")
                             .or_else(|| json_value.get("filename"))
                             .and_then(|v| v.as_str())
                             .unwrap_or("generated_meme.png")
                             .to_string();
 
-                        let image_format = json_value.get("image_format")
+                        let image_format = json_value
+                            .get("image_format")
                             .or_else(|| json_value.get("format"))
                             .and_then(|v| v.as_str())
                             .unwrap_or("png")
                             .to_string();
 
                         let metadata = PythonMetadata {
-                            processing_time: json_value.get("processing_time")
+                            processing_time: json_value
+                                .get("processing_time")
                                 .and_then(|v| v.as_f64())
                                 .unwrap_or(1.0),
-                            timestamp: json_value.get("timestamp")
+                            timestamp: json_value
+                                .get("timestamp")
                                 .and_then(|v| v.as_u64())
                                 .unwrap_or(time()),
-                            file_size_bytes: json_value.get("file_size_bytes")
+                            file_size_bytes: json_value
+                                .get("file_size_bytes")
                                 .or_else(|| json_value.get("file_size"))
                                 .and_then(|v| v.as_u64())
                                 .unwrap_or(1024000),
-                            service: json_value.get("service")
+                            service: json_value
+                                .get("service")
                                 .and_then(|v| v.as_str())
                                 .unwrap_or("icp-meme-generator")
                                 .to_string(),
@@ -507,25 +586,23 @@ pub fn list_meme_for_sale(meme_id: u64, price_e8s: u64) -> Result<(), String> {
         return Err("Authentication required".to_string());
     }
 
-    MEMES.with(|m| {
-        let mut map = m.borrow_mut();
-        if let Some(mut stored) = map.get(&meme_id) {
-            // Verify ownership
-            if stored.owner.0 != user {
-                return Err("You don't own this meme".to_string());
-            }
+    let owner = MEMES.with(|m| m.borrow().get(&meme_id).map(|stored| stored.owner.0));
+    let owner = owner.ok_or_else(|| "Meme not found".to_string())?;
 
-            // Update market data
-            stored.market_data.is_listed = true;
-            stored.market_data.listing_price = Some(price_e8s);
-            stored.market_data.listed_at = Some(time());
+    if owner != user {
+        return Err("You don't own this meme".to_string());
+    }
 
-            map.insert(meme_id, stored);
-            Ok(())
-        } else {
-            Err("Meme not found".to_string())
-        }
-    })
+    let token_id = crate::nft_module::get_token_by_meme_id(meme_id)
+        .ok_or_else(|| "Meme has not been minted as an NFT yet".to_string())?;
+
+    crate::nft_module::mutate_sale_metadata(&token_id, meme_id, |sale| {
+        sale.is_listed = true;
+        sale.listing_price = Some(price_e8s);
+        sale.listed_at = Some(time());
+    });
+
+    Ok(())
 }
 
 /// Remove a meme from the marketplace
@@ -536,25 +613,23 @@ pub fn remove_meme_from_market(meme_id: u64) -> Result<(), String> {
         return Err("Authentication required".to_string());
     }
 
-    MEMES.with(|m| {
-        let mut map = m.borrow_mut();
-        if let Some(mut stored) = map.get(&meme_id) {
-            // Verify ownership
-            if stored.owner.0 != user {
-                return Err("You don't own this meme".to_string());
-            }
+    let owner = MEMES.with(|m| m.borrow().get(&meme_id).map(|stored| stored.owner.0));
+    let owner = owner.ok_or_else(|| "Meme not found".to_string())?;
 
-            // Update market data
-            stored.market_data.is_listed = false;
-            stored.market_data.listing_price = None;
-            stored.market_data.listed_at = None;
+    if owner != user {
+        return Err("You don't own this meme".to_string());
+    }
 
-            map.insert(meme_id, stored);
-            Ok(())
-        } else {
-            Err("Meme not found".to_string())
-        }
-    })
+    if let Some(token_id) = crate::nft_module::get_token_by_meme_id(meme_id) {
+        crate::nft_module::mutate_sale_metadata(&token_id, meme_id, |sale| {
+            sale.is_listed = false;
+            sale.listing_price = None;
+            sale.listed_at = None;
+        });
+        Ok(())
+    } else {
+        Err("Meme has not been minted as an NFT yet".to_string())
+    }
 }
 
 /// Remove all memes from the marketplace (admin function)
@@ -568,31 +643,29 @@ pub fn remove_all_memes_from_market() -> Result<u32, String> {
     // Optional: Add admin check here if you have admin principals
     // For now, allowing any authenticated user
 
-    let mut removed_count = 0;
-    MEMES.with(|m| {
-        let mut map = m.borrow_mut();
-        let keys_to_update: Vec<u64> = map
-            .iter()
+    let keys_to_update: Vec<u64> = MEMES.with(|m| {
+        let map = m.borrow();
+        map.iter()
             .filter_map(|entry| {
-                let sm = entry.value();
-                if sm.market_data.is_listed {
-                    Some(*entry.key())
-                } else {
-                    None
-                }
+                let meme_id = *entry.key();
+                crate::nft_module::get_sale_metadata_for_meme(meme_id)
+                    .filter(|sale| sale.is_listed)
+                    .map(|_| meme_id)
             })
-            .collect();
-
-        for meme_id in keys_to_update {
-            if let Some(mut stored) = map.get(&meme_id) {
-                stored.market_data.is_listed = false;
-                stored.market_data.listing_price = None;
-                stored.market_data.listed_at = None;
-                map.insert(meme_id, stored);
-                removed_count += 1;
-            }
-        }
+            .collect()
     });
+
+    let mut removed_count = 0;
+    for meme_id in keys_to_update {
+        if let Some(token_id) = crate::nft_module::get_token_by_meme_id(meme_id) {
+            crate::nft_module::mutate_sale_metadata(&token_id, meme_id, |sale| {
+                sale.is_listed = false;
+                sale.listing_price = None;
+                sale.listed_at = None;
+            });
+            removed_count += 1;
+        }
+    }
 
     Ok(removed_count)
 }
@@ -652,9 +725,8 @@ pub fn delete_all_user_memes() -> Result<u32, String> {
     }
 
     // Get all meme IDs in the system
-    let all_meme_ids: Vec<u64> = MEMES.with(|m| {
-        m.borrow().iter().map(|entry| *entry.key()).collect()
-    });
+    let all_meme_ids: Vec<u64> =
+        MEMES.with(|m| m.borrow().iter().map(|entry| *entry.key()).collect());
 
     let mut deleted_count = 0;
     let mut failed_deletions = Vec::new();
@@ -691,7 +763,10 @@ pub fn delete_all_user_memes() -> Result<u32, String> {
 
             // Remove all voting data for this meme
             if let Err(e) = crate::voting::delete_meme_data(meme_id) {
-                failed_deletions.push(format!("Meme {}: voting data deletion failed: {}", meme_id, e));
+                failed_deletions.push(format!(
+                    "Meme {}: voting data deletion failed: {}",
+                    meme_id, e
+                ));
                 continue;
             }
 
@@ -703,7 +778,11 @@ pub fn delete_all_user_memes() -> Result<u32, String> {
 
     // If there were any failures, return an error with details
     if !failed_deletions.is_empty() {
-        return Err(format!("Deleted {} memes, but failed to delete: {}", deleted_count, failed_deletions.join(", ")));
+        return Err(format!(
+            "Deleted {} memes, but failed to delete: {}",
+            deleted_count,
+            failed_deletions.join(", ")
+        ));
     }
 
     Ok(deleted_count)
@@ -712,25 +791,25 @@ pub fn delete_all_user_memes() -> Result<u32, String> {
 /// Record a sale (called internally or by marketplace canister)
 #[update]
 pub fn record_meme_sale(meme_id: u64, sale_price_e8s: u64) -> Result<(), String> {
-    MEMES.with(|m| {
-        let mut map = m.borrow_mut();
-        if let Some(mut stored) = map.get(&meme_id) {
-            stored.market_data.total_sales += 1;
-            stored.market_data.total_earned += sale_price_e8s;
-            stored.market_data.last_sale_price = Some(sale_price_e8s);
-            stored.market_data.last_sale_at = Some(time());
+    let exists = MEMES.with(|m| m.borrow().contains_key(&meme_id));
+    if !exists {
+        return Err("Meme not found".to_string());
+    }
 
-            // Remove from market after sale
-            stored.market_data.is_listed = false;
-            stored.market_data.listing_price = None;
-            stored.market_data.listed_at = None;
-
-            map.insert(meme_id, stored);
-            Ok(())
-        } else {
-            Err("Meme not found".to_string())
-        }
-    })
+    if let Some(token_id) = crate::nft_module::get_token_by_meme_id(meme_id) {
+        crate::nft_module::mutate_sale_metadata(&token_id, meme_id, |sale| {
+            sale.total_sales = sale.total_sales.saturating_add(1);
+            sale.total_earned = sale.total_earned.saturating_add(sale_price_e8s);
+            sale.last_sale_price = Some(sale_price_e8s);
+            sale.last_sale_at = Some(time());
+            sale.is_listed = false;
+            sale.listing_price = None;
+            sale.listed_at = None;
+        });
+        Ok(())
+    } else {
+        Err("Meme has not been minted as an NFT yet".to_string())
+    }
 }
 
 /// Increment view count for a meme
@@ -739,7 +818,7 @@ pub fn increment_meme_views(meme_id: u64) -> Result<(), String> {
     MEMES.with(|m| {
         let mut map = m.borrow_mut();
         if let Some(mut stored) = map.get(&meme_id) {
-            stored.market_data.views += 1;
+            stored.views = stored.views.saturating_add(1);
             map.insert(meme_id, stored);
             Ok(())
         } else {
@@ -761,7 +840,7 @@ pub fn publish_meme(meme: MemeData) -> Result<PublicStoredMeme, String> {
 
     ic_cdk::println!("Publish meme - Authenticated user: {}", user.to_text());
     let now = time();
-    
+
     // Allocate id
     let id = next_meme_id();
 
@@ -770,18 +849,9 @@ pub fn publish_meme(meme: MemeData) -> Result<PublicStoredMeme, String> {
         id,
         owner: StorablePrincipal::from(user),
         meme_data: meme,
-        created_at: now,            // when published
-        canister_timestamp: now,    // canister-side write ts
-        market_data: MarketData {
-            is_listed: false,
-            listing_price: None,
-            listed_at: None,
-            total_sales: 0,
-            total_earned: 0,
-            last_sale_price: None,
-            last_sale_at: None,
-            views: 0,
-        },
+        created_at: now,         // when published
+        canister_timestamp: now, // canister-side write ts
+        views: 0,
     };
 
     // Insert into global index
@@ -836,9 +906,13 @@ pub fn get_marketplace_memes() -> Vec<PublicStoredMeme> {
             .iter()
             .filter_map(|entry| {
                 let sm = entry.value();
-                // Only include memes that are listed for sale
-                if sm.market_data.is_listed {
-                    let pm: PublicStoredMeme = sm.into();
+                let pm: PublicStoredMeme = sm.into();
+                if pm
+                    .sale_metadata
+                    .as_ref()
+                    .map(|sale| sale.is_listed)
+                    .unwrap_or(false)
+                {
                     Some(pm)
                 } else {
                     None
@@ -859,7 +933,7 @@ pub fn get_meme(meme_id: u64) -> Option<PublicStoredMeme> {
         let mut map = m.borrow_mut();
         if let Some(mut stored) = map.get(&meme_id) {
             // Increment view count
-            stored.market_data.views += 1;
+            stored.views = stored.views.saturating_add(1);
             map.insert(meme_id, stored.clone());
             Some(stored.into())
         } else {
@@ -872,11 +946,11 @@ pub fn get_meme(meme_id: u64) -> Option<PublicStoredMeme> {
 pub fn check_remaining_calls() -> u8 {
     let user = caller();
     let storable_user = StorablePrincipal::from(user);
-    
+
     // Get current day (in nanoseconds since epoch, converted to days)
     let now = time();
     let current_day = now / (24 * 60 * 60 * 1_000_000_000); // Convert ns to days
-    
+
     RATE.with(|r| {
         let rate_map = r.borrow();
         if let Some(usage) = rate_map.get(&storable_user) {
@@ -909,9 +983,13 @@ pub fn get_user_memes() -> Vec<PublicStoredMeme> {
             ids.sort_unstable_by(|a, b| b.cmp(a));
             MEMES.with(|m| {
                 let mem = m.borrow();
-                ids.into_iter().filter_map(|id| mem.get(&id).map(|sm| sm.into())).collect()
+                ids.into_iter()
+                    .filter_map(|id| mem.get(&id).map(|sm| sm.into()))
+                    .collect()
             })
-        } else { Vec::new() }
+        } else {
+            Vec::new()
+        }
     })
 }
 #[query]
@@ -922,7 +1000,15 @@ pub fn get_total_memes() -> u64 {
 pub fn get_user_meme_count() -> u32 {
     let user = caller();
     let storable_user = StorablePrincipal::from(user);
-    USER_MEMES.with(|um| um.borrow().get(&storable_user).map(|list| { let v: Vec<u64> = list.into(); v.len() as u32 }).unwrap_or(0))
+    USER_MEMES.with(|um| {
+        um.borrow()
+            .get(&storable_user)
+            .map(|list| {
+                let v: Vec<u64> = list.into();
+                v.len() as u32
+            })
+            .unwrap_or(0)
+    })
 }
 #[query]
 pub fn get_total_users() -> u64 {
@@ -937,7 +1023,12 @@ pub fn health() -> String {
 #[query]
 fn transform(args: TransformArgs) -> HttpResponse {
     let mut r = args.response;
-    r.headers.retain(|h| matches!(h.name.to_ascii_lowercase().as_str(), "content-type" | "content-length"));
+    r.headers.retain(|h| {
+        matches!(
+            h.name.to_ascii_lowercase().as_str(),
+            "content-type" | "content-length"
+        )
+    });
     r
 }
 
@@ -954,12 +1045,15 @@ pub async fn fetch_image_bytes_from_image_storage(url: &str) -> Result<Vec<u8>, 
 
     // Perform the async call to management canister
     let cycles: u64 = 21_000_000_000; // Attach enough cycles for HTTP outcall
-    let (response,): (HttpResponse,) = call_with_payment::<(CanisterHttpRequestArgument,), (HttpResponse,)>(
-        Principal::management_canister(),
-        "http_request",
-        (request,),
-        cycles
-    ).await.map_err(|e| format!("http_request call failed: {:?}", e))?;
+    let (response,): (HttpResponse,) =
+        call_with_payment::<(CanisterHttpRequestArgument,), (HttpResponse,)>(
+            Principal::management_canister(),
+            "http_request",
+            (request,),
+            cycles,
+        )
+        .await
+        .map_err(|e| format!("http_request call failed: {:?}", e))?;
 
     Ok(response.body)
 }

--- a/src/Mementic_backend/src/lib.rs
+++ b/src/Mementic_backend/src/lib.rs
@@ -1,46 +1,78 @@
-mod http_outcall;
-mod voting;
-mod nft_module;
 mod feedback;
+mod http_outcall;
+mod nft_module;
 mod user_profiles;
+mod voting;
 
-use candid::{CandidType, Nat, Principal, Decode, Encode};
-use ic_cdk::api::management_canister::http_request::TransformArgs;
-use ic_cdk::api::management_canister::http_request::HttpResponse;
 use crate::nft_module::InitArgs;
+use candid::{CandidType, Decode, Encode, Nat, Principal};
+use ic_cdk::api::management_canister::http_request::HttpResponse;
+use ic_cdk::api::management_canister::http_request::TransformArgs;
 use ic_cdk_macros::{query, update};
 use serde::{Deserialize, Serialize};
 
 pub use http_outcall::{
-    MemeData, PythonMetadata, StoredMeme, PublicStoredMeme, MarketData,
-    // queries
-    get_meme, get_user_memes, get_all_memes, get_marketplace_memes, get_total_memes, get_user_meme_count, get_total_users, health, check_remaining_calls, is_meme_minted,
+    check_remaining_calls,
     // updates
-    generate_meme, publish_meme, list_meme_for_sale, remove_meme_from_market, record_meme_sale,
+    generate_meme,
+    get_all_memes,
+    get_marketplace_memes,
+    // queries
+    get_meme,
+    get_total_memes,
+    get_total_users,
+    get_user_meme_count,
+    get_user_memes,
+    health,
+    increment_meme_views,
+    is_meme_minted,
+    list_meme_for_sale,
+    publish_meme,
+    record_meme_sale,
+    remove_meme_from_market,
+    MemeData,
+    PublicStoredMeme,
+    PythonMetadata,
+    StoredMeme,
 };
 
 pub use voting::{
-    MemeVotes, VoteRecord, VoteType, WeeklyPeriod, WeeklyLeaderboard, LeaderboardEntry, TopEntry,
-    VoteResponse, vote_meme, remove_vote, get_current_leaderboard, get_week_leaderboard,
-    get_top3_for_week, get_meme_votes, get_user_vote, get_completed_weeks,
-    get_current_week_status, finalize_finished_weeks, finalize_week, get_voting_stats,
+    finalize_finished_weeks, finalize_week, get_completed_weeks, get_current_leaderboard,
+    get_current_week_status, get_meme_votes, get_top3_for_week, get_user_vote, get_voting_stats,
+    get_week_leaderboard, remove_vote, vote_meme, LeaderboardEntry, MemeVotes, TopEntry,
+    VoteRecord, VoteResponse, VoteType, WeeklyLeaderboard, WeeklyPeriod,
 };
 
 pub use nft_module::{
-    SupportedStandard, TokenRecord, TokenMetadataEntry, MetadataValue, MintedPair, NftImage,
-    icrc7_name, icrc7_symbol, icrc7_total_supply, icrc7_supported_standards,
-    icrc7_owner_of, icrc7_tokens_of, get_token, get_token_by_meme_id, get_nft_image,
+    get_nft_image,
+    get_sale_metadata,
+    get_sale_metadata_for_meme,
+    get_token,
+    get_token_by_meme_id,
+    icrc7_name,
+    icrc7_owner_of,
+    icrc7_supported_standards,
+    icrc7_symbol,
+    icrc7_tokens_of,
+    icrc7_total_supply,
     // minting
     mint_week_top3_from_voting,
+    MetadataValue,
+    MintedPair,
+    NftImage,
+    SupportedStandard,
+    TokenMetadataEntry,
+    TokenRecord,
+    TokenSaleMetadata,
 };
 
 pub use feedback::{
-    Feedback, submit_feedback, get_approved_feedback, get_all_feedback,
-    approve_feedback, delete_feedback, get_feedback_stats, init_feedback_data,
+    approve_feedback, delete_feedback, get_all_feedback, get_approved_feedback, get_feedback_stats,
+    init_feedback_data, submit_feedback, Feedback,
 };
 
 pub use user_profiles::{
-    UserProfile, update_user_profile, get_user_profile, get_user_profile_by_principal,
+    get_user_profile, get_user_profile_by_principal, update_user_profile, UserProfile,
 };
 
 #[query]

--- a/src/Mementic_backend/src/nft_module.rs
+++ b/src/Mementic_backend/src/nft_module.rs
@@ -8,8 +8,10 @@ use ic_stable_structures::{
     DefaultMemoryImpl, StableBTreeMap,
 };
 
-use crate::{WeeklyPeriod, WeeklyLeaderboard, MemeVotes, VoteRecord, MemeData, VoteResponse, VoteType, TransformArgs, HttpResponse};
-
+use crate::{
+    HttpResponse, MemeData, MemeVotes, TransformArgs, VoteRecord, VoteResponse, VoteType,
+    WeeklyLeaderboard, WeeklyPeriod,
+};
 
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, cell::RefCell};
@@ -53,7 +55,10 @@ impl Storable for SNat {
 }
 
 impl Storable for SPrincipal {
-    const BOUND: Bound = Bound::Bounded { max_size: 64, is_fixed_size: false };
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 64,
+        is_fixed_size: false,
+    };
 
     fn to_bytes(&self) -> Cow<[u8]> {
         Cow::Owned(candid::Encode!(&self).expect("encode SPrincipal"))
@@ -155,6 +160,19 @@ pub struct TokenRecord {
     pub has_image: bool,           // indicates presence in STORED_IMAGES
 }
 
+#[derive(Clone, Debug, Default, CandidType, Serialize, Deserialize)]
+pub struct TokenSaleMetadata {
+    pub token_id: Nat,
+    pub meme_id: u64,
+    pub is_listed: bool,
+    pub listing_price: Option<u64>,
+    pub listed_at: Option<u64>,
+    pub total_sales: u64,
+    pub total_earned: u64,
+    pub last_sale_price: Option<u64>,
+    pub last_sale_at: Option<u64>,
+}
+
 #[derive(Clone, CandidType, Deserialize)]
 pub struct NftImage {
     pub mime_type: String,
@@ -162,7 +180,10 @@ pub struct NftImage {
 }
 
 #[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
-pub struct SupportedStandard { pub name: String, pub url: String }
+pub struct SupportedStandard {
+    pub name: String,
+    pub url: String,
+}
 
 impl Storable for TokenRecord {
     // Variable-size Candid; fine for values (not keys).
@@ -178,6 +199,22 @@ impl Storable for TokenRecord {
 
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         candid::Decode!(&bytes, TokenRecord).expect("decode TokenRecord")
+    }
+}
+
+impl Storable for TokenSaleMetadata {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(candid::Encode!(&self).expect("encode TokenSaleMetadata"))
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        candid::Encode!(&self).expect("encode TokenSaleMetadata")
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::Decode!(&bytes, TokenSaleMetadata).expect("decode TokenSaleMetadata")
     }
 }
 
@@ -202,6 +239,9 @@ thread_local! {
     // NEW: store actual image bytes (ImageBlob wraps Vec<u8>)
     static STORED_IMAGES: RefCell<StableBTreeMap<u64, ImageBlob, Mem>> =
         RefCell::new(StableBTreeMap::init(MEM_MGR.with(|m| m.borrow().get(MemoryId::new(4)))));
+
+    static TOKEN_SALES: RefCell<StableBTreeMap<SNat, TokenSaleMetadata, Mem>> =
+        RefCell::new(StableBTreeMap::init(MEM_MGR.with(|m| m.borrow().get(MemoryId::new(5)))));
 }
 
 // ---------- Init ----------
@@ -219,8 +259,14 @@ fn init(args: Option<InitArgs>) {
     let caller = ic_cdk::caller();
     STATE.with(|s| {
         let mut st = s.borrow_mut();
-        st.name = args.as_ref().and_then(|a| a.name.clone()).unwrap_or_else(|| "Mementic Top Memes".into());
-        st.symbol = args.as_ref().and_then(|a| a.symbol.clone()).unwrap_or_else(|| "MEME".into());
+        st.name = args
+            .as_ref()
+            .and_then(|a| a.name.clone())
+            .unwrap_or_else(|| "Mementic Top Memes".into());
+        st.symbol = args
+            .as_ref()
+            .and_then(|a| a.symbol.clone())
+            .unwrap_or_else(|| "MEME".into());
         st.description = args.as_ref().and_then(|a| a.description.clone());
         st.logo = args.as_ref().and_then(|a| a.logo.clone());
         st.admin = args.as_ref().and_then(|a| a.admin).unwrap_or(caller);
@@ -239,24 +285,36 @@ fn assert_admin() {
 }
 
 // ---------- ICRC-7-ish queries ----------
-#[query(name="icrc7_name")]
-pub fn icrc7_name() -> String { STATE.with(|s| s.borrow().name.clone()) }
+#[query(name = "icrc7_name")]
+pub fn icrc7_name() -> String {
+    STATE.with(|s| s.borrow().name.clone())
+}
 
-#[query(name="icrc7_symbol")]
-pub fn icrc7_symbol() -> String { STATE.with(|s| s.borrow().symbol.clone()) }
+#[query(name = "icrc7_symbol")]
+pub fn icrc7_symbol() -> String {
+    STATE.with(|s| s.borrow().symbol.clone())
+}
 
-#[query(name="icrc7_total_supply")]
-pub fn icrc7_total_supply() -> Nat { STATE.with(|s| s.borrow().total_supply.clone()) }
+#[query(name = "icrc7_total_supply")]
+pub fn icrc7_total_supply() -> Nat {
+    STATE.with(|s| s.borrow().total_supply.clone())
+}
 
-#[query(name="icrc7_supported_standards")]
+#[query(name = "icrc7_supported_standards")]
 pub fn icrc7_supported_standards() -> Vec<SupportedStandard> {
     vec![
-        SupportedStandard { name: "ICRC-7".into(), url: "https://github.com/dfinity/ICRC/ICRCs/ICRC-7".into() },
-        SupportedStandard { name: "ICRC-37".into(), url: "https://github.com/dfinity/ICRC/ICRCs/ICRC-37".into() },
+        SupportedStandard {
+            name: "ICRC-7".into(),
+            url: "https://github.com/dfinity/ICRC/ICRCs/ICRC-7".into(),
+        },
+        SupportedStandard {
+            name: "ICRC-37".into(),
+            url: "https://github.com/dfinity/ICRC/ICRCs/ICRC-37".into(),
+        },
     ]
 }
 
-#[query(name="icrc7_owner_of")]
+#[query(name = "icrc7_owner_of")]
 pub fn icrc7_owner_of(token_ids: Vec<Nat>) -> Vec<Option<Principal>> {
     TOKENS.with(|t| {
         let map = t.borrow();
@@ -267,9 +325,14 @@ pub fn icrc7_owner_of(token_ids: Vec<Nat>) -> Vec<Option<Principal>> {
     })
 }
 
-#[query(name="icrc7_tokens_of")]
+#[query(name = "icrc7_tokens_of")]
 pub fn icrc7_tokens_of(owner: Principal) -> Vec<Nat> {
-    OWNER_INDEX.with(|idx| idx.borrow().get(&SPrincipal(owner)).map(|ot| ot.0.clone()).unwrap_or_default())
+    OWNER_INDEX.with(|idx| {
+        idx.borrow()
+            .get(&SPrincipal(owner))
+            .map(|ot| ot.0.clone())
+            .unwrap_or_default()
+    })
 }
 
 #[query]
@@ -286,11 +349,47 @@ pub fn get_token_by_meme_id(meme_id: u64) -> Option<Nat> {
 pub fn get_nft_image(token_id: Nat) -> Option<NftImage> {
     let rec_opt = TOKENS.with(|t| t.borrow().get(&SNat(token_id.clone())));
     let rec = rec_opt?;
-    let mime = rec.mime_type.clone().unwrap_or("application/octet-stream".to_string());
+    let mime = rec
+        .mime_type
+        .clone()
+        .unwrap_or("application/octet-stream".to_string());
     let img_blob = STORED_IMAGES.with(|imgs| imgs.borrow().get(&rec.meme_id))?;
     Some(NftImage {
         mime_type: mime,
         image: img_blob.0.clone(),
+    })
+}
+
+#[query]
+pub fn get_sale_metadata(token_id: Nat) -> Option<TokenSaleMetadata> {
+    TOKEN_SALES.with(|sales| sales.borrow().get(&SNat(token_id)))
+}
+
+#[query]
+pub fn get_sale_metadata_for_meme(meme_id: u64) -> Option<TokenSaleMetadata> {
+    let token_id = get_token_by_meme_id(meme_id)?;
+    TOKEN_SALES.with(|sales| sales.borrow().get(&SNat(token_id)))
+}
+
+pub fn mutate_sale_metadata<F>(token_id: &Nat, meme_id: u64, mutator: F) -> TokenSaleMetadata
+where
+    F: FnOnce(&mut TokenSaleMetadata),
+{
+    TOKEN_SALES.with(|sales| {
+        let mut map = sales.borrow_mut();
+        let mut record = map
+            .get(&SNat(token_id.clone()))
+            .unwrap_or_else(|| TokenSaleMetadata {
+                token_id: token_id.clone(),
+                meme_id,
+                ..Default::default()
+            });
+        record.token_id = token_id.clone();
+        record.meme_id = meme_id;
+        let mut_record = &mut record;
+        mutator(mut_record);
+        map.insert(SNat(token_id.clone()), record.clone());
+        record
     })
 }
 
@@ -325,7 +424,7 @@ fn guess_content_type(ext: &str) -> Option<String> {
     }
 }
 
-fn build_metadata(m: &PublicStoredMeme) -> Vec<TokenMetadataEntry> {
+fn build_metadata(m: &PublicStoredMeme, token_id: &Nat) -> Vec<TokenMetadataEntry> {
     let ct = guess_content_type(&m.meme_data.image_format);
 
     let mut root: Vec<TokenMetadataEntry> = vec![
@@ -339,17 +438,48 @@ fn build_metadata(m: &PublicStoredMeme) -> Vec<TokenMetadataEntry> {
             immutable: true,
             value: MetadataValue::Map(vec![
                 ("meme:id".into(), MetadataValue::Text(m.id.to_string())),
-                ("meme:prompt".into(), MetadataValue::Text(m.meme_data.prompt.clone())),
-                ("meme:caption".into(), MetadataValue::Text(m.meme_data.caption.clone().unwrap_or_default())),
-                ("meme:filename".into(), MetadataValue::Text(m.meme_data.image_filename.clone())),
-                ("meme:format".into(), MetadataValue::Text(m.meme_data.image_format.clone())),
-                ("meme:service".into(), MetadataValue::Text(m.meme_data.metadata.service.clone())),
-                ("meme:ai_timestamp_ns".into(), MetadataValue::Text(m.meme_data.metadata.timestamp.to_string())),
-                ("meme:file_size_bytes".into(), MetadataValue::Text(m.meme_data.metadata.file_size_bytes.to_string())),
-                ("meme:created_at_ns".into(), MetadataValue::Text(m.created_at.to_string())),
-                ("meme:stored_at_ns".into(), MetadataValue::Text(m.canister_timestamp.to_string())),
+                (
+                    "meme:prompt".into(),
+                    MetadataValue::Text(m.meme_data.prompt.clone()),
+                ),
+                (
+                    "meme:caption".into(),
+                    MetadataValue::Text(m.meme_data.caption.clone().unwrap_or_default()),
+                ),
+                (
+                    "meme:filename".into(),
+                    MetadataValue::Text(m.meme_data.image_filename.clone()),
+                ),
+                (
+                    "meme:format".into(),
+                    MetadataValue::Text(m.meme_data.image_format.clone()),
+                ),
+                (
+                    "meme:service".into(),
+                    MetadataValue::Text(m.meme_data.metadata.service.clone()),
+                ),
+                (
+                    "meme:ai_timestamp_ns".into(),
+                    MetadataValue::Text(m.meme_data.metadata.timestamp.to_string()),
+                ),
+                (
+                    "meme:file_size_bytes".into(),
+                    MetadataValue::Text(m.meme_data.metadata.file_size_bytes.to_string()),
+                ),
+                (
+                    "meme:created_at_ns".into(),
+                    MetadataValue::Text(m.created_at.to_string()),
+                ),
+                (
+                    "meme:stored_at_ns".into(),
+                    MetadataValue::Text(m.canister_timestamp.to_string()),
+                ),
+                (
+                    "nft:token_id".into(),
+                    MetadataValue::Text(token_id.to_string()),
+                ),
             ]),
-        }
+        },
     ];
 
     if let Some(ctext) = ct {
@@ -364,15 +494,25 @@ fn build_metadata(m: &PublicStoredMeme) -> Vec<TokenMetadataEntry> {
 }
 
 // ---------- X-canister clients ----------
-async fn voting_get_top3_for_week(voting_canister: Principal, week_id: u64) -> Result<Vec<TopEntry>, String> {
+async fn voting_get_top3_for_week(
+    voting_canister: Principal,
+    week_id: u64,
+) -> Result<Vec<TopEntry>, String> {
     use ic_cdk::api::call::call;
-    call::<(u64,), (Result<Vec<TopEntry>, String>,)>(voting_canister, "get_top3_for_week", (week_id,))
-        .await
-        .map(|(res,)| res)
-        .map_err(|e| format!("get_top3_for_week call failed: {:?}", e))?
+    call::<(u64,), (Result<Vec<TopEntry>, String>,)>(
+        voting_canister,
+        "get_top3_for_week",
+        (week_id,),
+    )
+    .await
+    .map(|(res,)| res)
+    .map_err(|e| format!("get_top3_for_week call failed: {:?}", e))?
 }
 
-async fn voting_get_meme_data(voting_canister: Principal, meme_id: u64) -> Result<Option<PublicStoredMeme>, String> {
+async fn voting_get_meme_data(
+    voting_canister: Principal,
+    meme_id: u64,
+) -> Result<Option<PublicStoredMeme>, String> {
     use ic_cdk::api::call::call;
     call::<(u64,), (Option<PublicStoredMeme>,)>(voting_canister, "get_meme", (meme_id,))
         .await
@@ -382,7 +522,11 @@ async fn voting_get_meme_data(voting_canister: Principal, meme_id: u64) -> Resul
 
 // ---------- Public: mint Top-3 (now fetches image bytes before minting) ----------
 #[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
-pub struct MintedPair { pub meme_id: u64, pub token_id: Nat, pub owner: Principal }
+pub struct MintedPair {
+    pub meme_id: u64,
+    pub token_id: Nat,
+    pub owner: Principal,
+}
 
 #[update]
 async fn mint_to(meme_id: u64) -> Result<Nat, String> {
@@ -392,17 +536,25 @@ async fn mint_to(meme_id: u64) -> Result<Nat, String> {
     }
 
     let voting_canister = ic_cdk::api::id();
-    let stored_meme_data = voting_get_meme_data(voting_canister, meme_id).await?
+    let stored_meme_data = voting_get_meme_data(voting_canister, meme_id)
+        .await?
         .ok_or_else(|| format!("StoredMeme {} not found in voting canister", meme_id))?;
 
     let image_url = stored_meme_data.meme_data.image_url.clone();
     let image_format = stored_meme_data.meme_data.image_format.clone();
-    let mime_type = guess_content_type(&image_format).unwrap_or_else(|| "application/octet-stream".into());
+    let mime_type =
+        guess_content_type(&image_format).unwrap_or_else(|| "application/octet-stream".into());
 
-    let image_bytes = match crate::http_outcall::fetch_image_bytes_from_image_storage(&image_url).await {
-        Ok(b) => b,
-        Err(e) => return Err(format!("failed to fetch image for meme {} : {}", meme_id, e)),
-    };
+    let image_bytes =
+        match crate::http_outcall::fetch_image_bytes_from_image_storage(&image_url).await {
+            Ok(b) => b,
+            Err(e) => {
+                return Err(format!(
+                    "failed to fetch image for meme {} : {}",
+                    meme_id, e
+                ))
+            }
+        };
 
     // Store image bytes in STORED_IMAGES under meme_id
     STORED_IMAGES.with(|imgs| {
@@ -411,7 +563,7 @@ async fn mint_to(meme_id: u64) -> Result<Nat, String> {
 
     // Generate token_id and build token metadata
     let token_id = next_token_id();
-    let mut metadata = build_metadata(&stored_meme_data);
+    let mut metadata = build_metadata(&stored_meme_data, &token_id);
 
     // Add content type to metadata (ensures downstream clients can read content type)
     metadata.push(TokenMetadataEntry {
@@ -434,6 +586,7 @@ async fn mint_to(meme_id: u64) -> Result<Nat, String> {
     TOKENS.with(|t| t.borrow_mut().insert(SNat(token_id.clone()), rec));
     push_owner(stored_meme_data.owner, &token_id);
     MINT_INDEX.with(|mi| mi.borrow_mut().insert(meme_id, SNat(token_id.clone())));
+    mutate_sale_metadata(&token_id, meme_id, |_| {});
 
     Ok(token_id)
 }
@@ -448,14 +601,22 @@ pub async fn mint_week_top3_from_voting(week_id: u64) -> Result<Vec<MintedPair>,
 
     let voting_canister = ic_cdk::api::id();
     let winners = voting_get_top3_for_week(voting_canister, week_id).await?;
-    if winners.is_empty() { return Ok(vec![]); }
+    if winners.is_empty() {
+        return Ok(vec![]);
+    }
 
     let mut minted: Vec<MintedPair> = Vec::new();
     for w in winners.into_iter() {
         let token_id = mint_to(w.meme_id).await?;
         // Fetch owner from token record
-        let owner = TOKENS.with(|t| t.borrow().get(&SNat(token_id.clone())).map(|rec| rec.owner)).unwrap_or(Principal::anonymous());
-        minted.push(MintedPair { meme_id: w.meme_id, token_id, owner });
+        let owner = TOKENS
+            .with(|t| t.borrow().get(&SNat(token_id.clone())).map(|rec| rec.owner))
+            .unwrap_or(Principal::anonymous());
+        minted.push(MintedPair {
+            meme_id: w.meme_id,
+            token_id,
+            owner,
+        });
     }
 
     WEEK_MINTED.with(|wm| wm.borrow_mut().insert(week_id, true));

--- a/src/Mementic_frontend/src/Pages/Auction.jsx
+++ b/src/Mementic_frontend/src/Pages/Auction.jsx
@@ -200,12 +200,13 @@ const normalizeMeme = (m, extra = {}) => {
   const createdAt =
     createdAtCandidates.find((value) => value && value > 0) ?? Date.now();
 
-  const marketData = md?.market_data ?? m?.market_data ?? {};
-  const listingPriceIcp = convertE8sToIcp(unwrapOptional(marketData?.listing_price));
-  const listedAt = normalizeTimestampToMs(unwrapOptional(marketData?.listed_at));
-  const views = safeBigIntToNumber(
-    unwrapOptional(marketData?.views) ?? m?.views ?? md?.views ?? 0
+  const saleMetadata =
+    md?.sale_metadata ?? m?.sale_metadata ?? md?.market_data ?? m?.market_data ?? {};
+  const listingPriceIcp = convertE8sToIcp(
+    unwrapOptional(saleMetadata?.listing_price)
   );
+  const listedAt = normalizeTimestampToMs(unwrapOptional(saleMetadata?.listed_at));
+  const views = safeBigIntToNumber(m?.views ?? md?.views ?? 0);
 
   return {
     id: toSafeIdString(m?.id ?? m?.meme_id ?? m?._id ?? m?.uuid ?? Date.now()),
@@ -224,7 +225,8 @@ const normalizeMeme = (m, extra = {}) => {
     created_at: createdAt,
     listed_at: listedAt || null,
     listingPriceIcp,
-    market_data: marketData,
+    sale_metadata: saleMetadata,
+    market_data: saleMetadata,
     metadata_service: metadata?.service ? String(metadata.service) : null,
     rank: safeBigIntToNumber(extra?.rank ?? m?.rank ?? 0),
     __raw: m,
@@ -390,7 +392,11 @@ const Auction = () => {
   }, []);
 
   const liveAuctions = useMemo(
-    () => auctions.filter((meme) => meme.market_data?.is_listed ?? true),
+    () =>
+      auctions.filter((meme) => {
+        const sale = meme?.sale_metadata ?? meme?.market_data;
+        return sale?.is_listed ?? true;
+      }),
     [auctions]
   );
 

--- a/src/Mementic_frontend/src/Pages/Portfolio.jsx
+++ b/src/Mementic_frontend/src/Pages/Portfolio.jsx
@@ -276,7 +276,7 @@ const Portfolio = () => {
   // Map canister records -> UI
   const mapToUi = (item) => {
     const memeData = unopt(item?.meme_data) || {};
-    const marketData = item?.market_data || {};
+    const marketData = item?.sale_metadata ?? item?.market_data ?? {};
     const votes = safeBigIntToNumber(item?.votes?.upvotes ?? item?.votes ?? 0);
 
     // Handle bigint conversion for earned ICP (from market data)
@@ -297,7 +297,7 @@ const Portfolio = () => {
       emoji: "🖼️",
       votes: votes,
       earnedIcp: Number.isFinite(earnedIcp) ? earnedIcp : 0,
-      views: safeBigIntToNumber(marketData?.views || item?.views || 0),
+      views: safeBigIntToNumber(item?.views || marketData?.views || 0),
       status,
       imageUrl: memeData?.image_url,
       // Market data
@@ -344,13 +344,16 @@ const Portfolio = () => {
               }
             },
             created_at: Date.now(),
-            market_data: {
+            sale_metadata: {
               is_listed: false,
               listing_price: null,
-              views: 0,
+              listed_at: null,
               total_sales: 0,
-              total_earned: 0
-            }
+              total_earned: 0,
+              last_sale_price: null,
+              last_sale_at: null
+            },
+            views: 0
           }
         ];
         console.log("Using sample data due to backend issues");

--- a/src/Mementic_frontend/src/Pages/PreMarketplace.jsx
+++ b/src/Mementic_frontend/src/Pages/PreMarketplace.jsx
@@ -91,7 +91,11 @@ const PreMarketplace = () => {
   );
 
   const listedCount = useMemo(
-    () => memes.filter((meme) => meme?.market_data?.is_listed).length,
+    () =>
+      memes.filter((meme) => {
+        const sale = meme?.sale_metadata ?? meme?.market_data;
+        return sale?.is_listed;
+      }).length,
     [memes]
   );
 

--- a/src/Mementic_frontend/src/components/MemeCard.jsx
+++ b/src/Mementic_frontend/src/components/MemeCard.jsx
@@ -51,6 +51,7 @@ export const MemeCard = ({
       : Number(rawVotes) || 0;
   const image = meme?.image_url || meme?.imageUrl || "";
   const memeId = meme?.id || meme?.meme_id;
+  const sale = meme?.sale_metadata ?? meme?.market_data;
 
   // Enhanced ownership detection with multiple fallback methods
   const checkOwnership = () => {
@@ -587,14 +588,12 @@ export const MemeCard = ({
                           })}
                         </span>
                       </div>
-                      {meme?.market_data?.is_listed && (
+                      {sale?.is_listed && (
                         <div className="flex justify-between py-2 border-b border-gray-100 dark:border-gray-800">
                           <span className="font-medium">Price:</span>
                           <span className="font-semibold text-green-600">
-                            {meme.market_data.listing_price
-                              ? (
-                                  meme.market_data.listing_price / 100000000
-                                ).toFixed(2)
+                            {sale.listing_price
+                              ? (sale.listing_price / 100000000).toFixed(2)
                               : "N/A"}{" "}
                             ICP
                           </span>

--- a/src/Mementic_frontend/src/components/marketplace/MarketplaceFeed.jsx
+++ b/src/Mementic_frontend/src/components/marketplace/MarketplaceFeed.jsx
@@ -45,7 +45,11 @@ const MarketplaceFeed = ({
   );
 
   const listedCount = useMemo(
-    () => ensureArray(memes).filter((meme) => meme?.market_data?.is_listed).length,
+    () =>
+      ensureArray(memes).filter((meme) => {
+        const sale = meme?.sale_metadata ?? meme?.market_data;
+        return sale?.is_listed;
+      }).length,
     [memes]
   );
 

--- a/src/Mementic_frontend/src/hooks/useMarketplaceData.js
+++ b/src/Mementic_frontend/src/hooks/useMarketplaceData.js
@@ -237,6 +237,7 @@ export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, 
       const getCreatedAt = (meme) => safeBigIntToNumber(meme?.created_at || 0);
       const getVotes = (meme) => safeBigIntToNumber(meme?.votes || 0);
       const getViews = (meme) => safeBigIntToNumber(meme?.views || 0);
+      const getSale = (meme) => meme?.sale_metadata ?? meme?.market_data;
 
       if (sort === "newest") {
         arr.sort((a, b) => {
@@ -252,8 +253,8 @@ export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, 
         });
       } else if (sort === "listed") {
         arr.sort((a, b) => {
-          const aListed = a?.market_data?.is_listed ? 1 : 0;
-          const bListed = b?.market_data?.is_listed ? 1 : 0;
+          const aListed = getSale(a)?.is_listed ? 1 : 0;
+          const bListed = getSale(b)?.is_listed ? 1 : 0;
           if (aListed !== bListed) return bListed - aListed;
           const voteDiff = getVotes(b) - getVotes(a);
           if (voteDiff !== 0) return voteDiff;

--- a/src/Mementic_frontend/src/utils/marketplaceUtils.js
+++ b/src/Mementic_frontend/src/utils/marketplaceUtils.js
@@ -205,6 +205,8 @@ export const normalizeMeme = (m, extra = {}, userProfiles = new Map()) => {
   const createdAt =
     createdAtCandidates.find((value) => value && value > 0) ?? Date.now();
 
+  const saleMetadata = m?.sale_metadata ?? m?.market_data ?? null;
+
   return {
     id: toSafeIdString(m?.id ?? m?.meme_id ?? m?._id ?? m?.uuid ?? Date.now()),
     title:
@@ -218,11 +220,12 @@ export const normalizeMeme = (m, extra = {}, userProfiles = new Map()) => {
     creator,
     image_url,
     votes: score,
-    views: safeBigIntToNumber(m?.market_data?.views ?? m?.views ?? 0),
+    views: safeBigIntToNumber(m?.views ?? saleMetadata?.views ?? 0),
     created_at: createdAt,
     rank: safeBigIntToNumber(extra?.rank ?? m?.rank ?? 0),
     emoji: m?.emoji || "🖼️",
-    market_data: m?.market_data,
+    sale_metadata: saleMetadata,
+    market_data: saleMetadata,
     __raw: m,
   };
 };


### PR DESCRIPTION
## Summary
- add TokenSaleMetadata stable storage so listing data is tracked per NFT rather than per generated meme
- update canister APIs and candid definitions to expose optional sale metadata alongside meme views
- refresh frontend marketplace/portfolio logic to read optional sale metadata and ensure generated memes surface without pricing, and add the provided architecture review note

## Testing
- `cargo check`
- `npm run build` *(fails: dfx binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecdb39a824832bb30ad126142fd0c0