### PR TITLE
Add marketplace metrics to NFT summaries and listings

### DIFF
--- a/src/Mementic_backend/Mementic_backend.did
+++ b/src/Mementic_backend/Mementic_backend.did
@@ -76,11 +76,63 @@ type Result_4 = variant { Ok : nat; Err : text };
 type Result_5 = variant { Ok : vec MintedPair; Err : text };
 type Result_6 = variant { Ok : PublicStoredMeme; Err : text };
 type Result_7 = variant { Ok : VoteResponse; Err : text };
+type Result_8 = variant { Ok : vec nat; Err : text };
 type SupportedStandard = record { url : text; name : text };
 type TokenMetadataEntry = record {
   value : MetadataValue;
   name : text;
   immutable : bool;
+};
+type NftMetadata = record {
+  name : text;
+  symbol : text;
+  description : opt text;
+  royalty_bps : opt nat16;
+  external_url : opt text;
+  attributes : vec record { text; text };
+  license : opt text;
+  image_uri : text;
+};
+type NftMarketInfo = record {
+  listed : bool;
+  listing_price : opt nat;
+  listed_quantity : nat32;
+  total_volume : nat;
+  floor_price : opt nat;
+  last_sale_price : opt nat;
+  last_sale_at : opt nat64;
+  total_sales : nat64;
+  ranking : opt nat32;
+  current_owner : opt principal;
+};
+type NftSummary = record {
+  meme_id : nat64;
+  token_id : nat;
+  name : text;
+  image_uri : text;
+  is_collection : bool;
+  edition_size : opt nat32;
+  owned_quantity : nat32;
+  market : NftMarketInfo;
+};
+type Listing = record {
+  listing_id : nat;
+  token_id : nat;
+  seller : principal;
+  unit_price : nat;
+  quantity : nat32;
+  created_at_ns : nat64;
+  expires_at_ns : opt nat64;
+  active : bool;
+};
+type MarketplaceListing = record {
+  listing : Listing;
+  meme_id : nat64;
+  name : text;
+  image_uri : text;
+  is_collection : bool;
+  edition_size : opt nat32;
+  market : NftMarketInfo;
 };
 type TokenRecord = record {
   meme_id : nat64;
@@ -90,17 +142,26 @@ type TokenRecord = record {
   mime_type : opt text;
   has_image : bool;
   minted_at : nat64;
+  minted_by : principal;
+  edition_number : opt nat32;
+  edition_size : opt nat32;
+  custom_metadata : opt NftMetadata;
 };
 type TokenSaleMetadata = record {
-  listing_price : opt nat64;
-  total_sales : nat64;
+  listing_price : opt nat;
+  listed_quantity : nat32;
   meme_id : nat64;
   token_id : nat;
-  last_sale_price : opt nat64;
+  total_sales : nat64;
+  total_earned : nat;
+  last_sale_price : opt nat;
   is_listed : bool;
   last_sale_at : opt nat64;
-  total_earned : nat64;
   listed_at : opt nat64;
+  floor_price : opt nat;
+  total_volume : nat;
+  current_owner : opt principal;
+  ranking_hint : opt nat32;
 };
 type TopEntry = record {
   upvotes : nat32;
@@ -184,6 +245,7 @@ service : (opt InitArgs) -> {
   // Return **Top 3** for a given week (for NFT mint step).
   // Fails if the week is not completed yet.
   get_top3_for_week : (nat64) -> (Result_3) query;
+  get_user_listings : (opt principal) -> (vec MarketplaceListing) query;
   get_total_memes : () -> (nat64) query;
   get_total_users : () -> (nat64) query;
   get_user_meme_count : () -> (nat32) query;
@@ -194,6 +256,7 @@ service : (opt InitArgs) -> {
   get_user_vote : (nat64) -> (opt VoteRecord) query;
   // Leaderboard for any week id. Returns None if week not found.
   get_week_leaderboard : (nat64, opt nat32) -> (opt WeeklyLeaderboard) query;
+  get_weekly_winners : (text) -> (vec nat64) query;
   health : () -> (text) query;
   icrc7_name : () -> (text) query;
   icrc7_owner_of : (vec nat) -> (vec opt principal) query;
@@ -204,24 +267,26 @@ service : (opt InitArgs) -> {
   // Increment view count for a meme
   increment_meme_views : (nat64) -> (Result_2);
   // Check if a meme has been minted as an NFT
-  is_meme_minted : (nat64) -> (bool) query;
-  // List a meme for sale on the marketplace
-  list_meme_for_sale : (nat64, nat64) -> (Result_2);
+  is_winner : (nat64) -> (bool) query;
+  list_for_sale : (nat, nat, nat32, opt nat64) -> (Result_4);
+  mint_collection_nft : (nat64, nat32, NftMetadata) -> (Result_8);
+  mint_single_nft : (nat64, NftMetadata) -> (Result_4);
   mint_to : (nat64) -> (Result_4);
   mint_week_top3_from_voting : (nat64) -> (Result_5);
   mint_week_top3_here : (nat64) -> (Result_5);
+  my_minted_nfts : (opt principal) -> (vec NftSummary) query;
   // Store a generated meme into marketplace (associated to caller)
   publish_meme : (MemeData) -> (Result_6);
-  // Record a sale (called internally or by marketplace canister)
-  record_meme_sale : (nat64, nat64) -> (Result_2);
   // Remove all memes from the marketplace (admin function)
   remove_all_memes_from_market : () -> (Result_1);
-  // Remove a meme from the marketplace
-  remove_meme_from_market : (nat64) -> (Result_2);
   // Remove your vote (works only for current active week)
   remove_vote : (nat64) -> (Result_7);
+  show_all_nfts_for_sale : (nat64, nat32) -> (vec MarketplaceListing) query;
   // Submit feedback from a user
   submit_feedback : (text, text, text, text, bool) -> (Result);
+  cancel_listing : (nat) -> (Result_2);
+  buy : (nat, nat32) -> (Result_2);
+  update_listing : (nat, opt nat, opt nat32, opt nat64) -> (Result_2);
   transform : (TransformArgs) -> (HttpResponse) query;
   update_user_profile : (opt text, opt text) -> (Result_2);
   // Cast or change a vote on a meme in the **current active week**.

--- a/src/Mementic_backend/src/lib.rs
+++ b/src/Mementic_backend/src/lib.rs
@@ -5,11 +5,10 @@ mod user_profiles;
 mod voting;
 
 use crate::nft_module::InitArgs;
-use candid::{CandidType, Decode, Encode, Nat, Principal};
+use candid::{Nat, Principal};
 use ic_cdk::api::management_canister::http_request::HttpResponse;
 use ic_cdk::api::management_canister::http_request::TransformArgs;
 use ic_cdk_macros::{query, update};
-use serde::{Deserialize, Serialize};
 
 pub use http_outcall::{
     check_remaining_calls,
@@ -25,11 +24,7 @@ pub use http_outcall::{
     get_user_memes,
     health,
     increment_meme_views,
-    is_meme_minted,
-    list_meme_for_sale,
     publish_meme,
-    record_meme_sale,
-    remove_meme_from_market,
     MemeData,
     PublicStoredMeme,
     PythonMetadata,
@@ -44,26 +39,13 @@ pub use voting::{
 };
 
 pub use nft_module::{
-    get_nft_image,
-    get_sale_metadata,
-    get_sale_metadata_for_meme,
-    get_token,
-    get_token_by_meme_id,
-    icrc7_name,
-    icrc7_owner_of,
-    icrc7_supported_standards,
-    icrc7_symbol,
-    icrc7_tokens_of,
-    icrc7_total_supply,
-    // minting
-    mint_week_top3_from_voting,
-    MetadataValue,
-    MintedPair,
-    NftImage,
-    SupportedStandard,
-    TokenMetadataEntry,
-    TokenRecord,
-    TokenSaleMetadata,
+    buy, cancel_listing, get_nft_image, get_sale_metadata, get_sale_metadata_for_meme, get_token,
+    get_token_by_meme_id, get_user_listings, icrc7_name, icrc7_owner_of, icrc7_supported_standards,
+    icrc7_symbol, icrc7_tokens_of, icrc7_total_supply, list_for_sale, mint_collection_nft,
+    mint_single_nft, mint_week_top3_from_voting, my_minted_nfts, show_all_nfts_for_sale,
+    update_listing, Listing, ListingId, MarketplaceListing, MemeId, MetadataValue, MintedPair,
+    NftImage, NftMarketInfo, NftMetadata, NftSummary, SupportedStandard, TokenMetadataEntry,
+    TokenRecord, TokenSaleMetadata,
 };
 
 pub use feedback::{

--- a/src/Mementic_backend/src/nft_module.rs
+++ b/src/Mementic_backend/src/nft_module.rs
@@ -1,4 +1,4 @@
- // src/lib.rs
+// src/lib.rs
 use candid::{CandidType, Decode, Encode, Nat, Principal};
 use ic_cdk::api::time;
 use ic_cdk_macros::{init, query, update};
@@ -8,18 +8,19 @@ use ic_stable_structures::{
     DefaultMemoryImpl, StableBTreeMap,
 };
 
-use crate::{
-    HttpResponse, MemeData, MemeVotes, TransformArgs, VoteRecord, VoteResponse, VoteType,
-    WeeklyLeaderboard, WeeklyPeriod,
-};
+use crate::{PublicStoredMeme, TopEntry};
 
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, cell::RefCell};
 
 // Import shared types (must exist in your crate)
-use crate::http_outcall::PublicStoredMeme;
-use crate::TopEntry;
 
+pub type MemeId = u64;
+pub type ListingId = u128;
+
+// Re-use Nat as the public token identifier to remain backward compatible with the
+// existing candid surface until a full ICRC-7 refactor lands. Internally we still
+// treat it as a bigint so callers can downcast to u128 when needed.
 // ---------- Stable memory ----------
 type Mem = VirtualMemory<DefaultMemoryImpl>;
 
@@ -32,6 +33,12 @@ pub struct SPrincipal(pub Principal);
 
 #[derive(Clone, Debug, Default, CandidType, Serialize, Deserialize)]
 pub struct OwnerTokens(pub Vec<Nat>);
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SListingId(pub ListingId);
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct ListingCounter(pub ListingId);
 
 // Wrapper for storing image bytes in stable map (so Vec<u8> is Storable)
 #[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
@@ -90,6 +97,44 @@ impl Storable for OwnerTokens {
     }
 }
 
+impl Storable for SListingId {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 32,
+        is_fixed_size: true,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(candid::Encode!(&self).expect("encode SListingId"))
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        candid::Encode!(&self).expect("encode SListingId")
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::Decode!(&bytes, SListingId).expect("decode SListingId")
+    }
+}
+
+impl Storable for ListingCounter {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 32,
+        is_fixed_size: true,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(candid::Encode!(&self).expect("encode ListingCounter"))
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        candid::Encode!(&self).expect("encode ListingCounter")
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::Decode!(&bytes, ListingCounter).expect("decode ListingCounter")
+    }
+}
+
 impl Storable for ImageBlob {
     const BOUND: Bound = Bound::Unbounded;
 
@@ -113,7 +158,7 @@ pub struct CollectionState {
     pub symbol: String,
     pub description: Option<String>,
     pub logo: Option<String>,
-    pub total_supply: Nat,
+    pub total_supply: u128,
     pub admin: Principal,
     pub created_at: u64,
 }
@@ -125,7 +170,7 @@ impl Default for CollectionState {
             symbol: String::new(),
             description: None,
             logo: None,
-            total_supply: Nat::from(0u32),
+            total_supply: 0u128,
             admin: Principal::anonymous(),
             created_at: 0,
         }
@@ -148,6 +193,18 @@ pub enum MetadataValue {
     Array(Vec<MetadataValue>),
 }
 
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct NftMetadata {
+    pub name: String,
+    pub symbol: String,
+    pub description: Option<String>,
+    pub royalty_bps: Option<u16>,
+    pub external_url: Option<String>,
+    pub attributes: Vec<(String, String)>,
+    pub license: Option<String>,
+    pub image_uri: String,
+}
+
 // Token record: note CandidType added and metadata uses Vec<TokenMetadataEntry>
 #[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
 pub struct TokenRecord {
@@ -158,6 +215,10 @@ pub struct TokenRecord {
     pub metadata: Vec<TokenMetadataEntry>,
     pub mime_type: Option<String>, // small
     pub has_image: bool,           // indicates presence in STORED_IMAGES
+    pub minted_by: Principal,
+    pub edition_number: Option<u32>,
+    pub edition_size: Option<u32>,
+    pub custom_metadata: Option<NftMetadata>,
 }
 
 #[derive(Clone, Debug, Default, CandidType, Serialize, Deserialize)]
@@ -165,12 +226,31 @@ pub struct TokenSaleMetadata {
     pub token_id: Nat,
     pub meme_id: u64,
     pub is_listed: bool,
-    pub listing_price: Option<u64>,
+    pub listing_price: Option<u128>,
+    pub listed_quantity: u32,
     pub listed_at: Option<u64>,
     pub total_sales: u64,
-    pub total_earned: u64,
-    pub last_sale_price: Option<u64>,
+    pub total_earned: u128,
+    pub last_sale_price: Option<u128>,
     pub last_sale_at: Option<u64>,
+    pub floor_price: Option<u128>,
+    pub total_volume: u128,
+    pub current_owner: Option<Principal>,
+    pub ranking_hint: Option<u32>,
+}
+
+#[derive(Clone, Debug, Default, CandidType, Serialize, Deserialize)]
+pub struct NftMarketInfo {
+    pub listed: bool,
+    pub listing_price: Option<u128>,
+    pub listed_quantity: u32,
+    pub total_volume: u128,
+    pub floor_price: Option<u128>,
+    pub last_sale_price: Option<u128>,
+    pub last_sale_at: Option<u64>,
+    pub total_sales: u64,
+    pub ranking: Option<u32>,
+    pub current_owner: Option<Principal>,
 }
 
 #[derive(Clone, CandidType, Deserialize)]
@@ -183,6 +263,69 @@ pub struct NftImage {
 pub struct SupportedStandard {
     pub name: String,
     pub url: String,
+}
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub enum MintingStatus {
+    Single {
+        token_id: Nat,
+        metadata: NftMetadata,
+    },
+    Collection {
+        token_ids: Vec<Nat>,
+        edition_size: u32,
+        metadata: NftMetadata,
+    },
+}
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct MintingInfo {
+    pub meme_id: MemeId,
+    pub minted_by: Principal,
+    pub minted_at: u64,
+    pub status: MintingStatus,
+}
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct NftSummary {
+    pub meme_id: MemeId,
+    pub token_id: Nat,
+    pub name: String,
+    pub image_uri: String,
+    pub is_collection: bool,
+    pub edition_size: Option<u32>,
+    pub owned_quantity: u32,
+    pub market: NftMarketInfo,
+}
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct Listing {
+    pub listing_id: ListingId,
+    pub token_id: Nat,
+    pub seller: Principal,
+    pub unit_price: u128,
+    pub quantity: u32,
+    pub created_at_ns: u64,
+    pub expires_at_ns: Option<u64>,
+    pub active: bool,
+}
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct ListingRecord {
+    pub listing: Listing,
+    pub meme_id: MemeId,
+    pub locked_token_ids: Vec<Nat>,
+}
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct MarketplaceListing {
+    pub listing: Listing,
+    pub meme_id: MemeId,
+    pub name: String,
+    pub image_uri: String,
+    pub is_collection: bool,
+    pub edition_size: Option<u32>,
+    pub market: NftMarketInfo,
 }
 
 impl Storable for TokenRecord {
@@ -218,6 +361,38 @@ impl Storable for TokenSaleMetadata {
     }
 }
 
+impl Storable for MintingInfo {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(candid::Encode!(&self).expect("encode MintingInfo"))
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        candid::Encode!(&self).expect("encode MintingInfo")
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::Decode!(&bytes, MintingInfo).expect("decode MintingInfo")
+    }
+}
+
+impl Storable for ListingRecord {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(candid::Encode!(&self).expect("encode ListingRecord"))
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        candid::Encode!(&self).expect("encode ListingRecord")
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::Decode!(&bytes, ListingRecord).expect("decode ListingRecord")
+    }
+}
+
 thread_local! {
     static MEM_MGR: RefCell<MemoryManager<DefaultMemoryImpl>> =
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
@@ -228,7 +403,7 @@ thread_local! {
     static OWNER_INDEX: RefCell<StableBTreeMap<SPrincipal, OwnerTokens, Mem>> =
         RefCell::new(StableBTreeMap::init(MEM_MGR.with(|m| m.borrow().get(MemoryId::new(1)))));
 
-    static MINT_INDEX: RefCell<StableBTreeMap<u64, SNat, Mem>> =
+    static MINT_INDEX: RefCell<StableBTreeMap<MemeId, MintingInfo, Mem>> =
         RefCell::new(StableBTreeMap::init(MEM_MGR.with(|m| m.borrow().get(MemoryId::new(2)))));
 
     static WEEK_MINTED: RefCell<StableBTreeMap<u64, bool, Mem>> =
@@ -242,6 +417,15 @@ thread_local! {
 
     static TOKEN_SALES: RefCell<StableBTreeMap<SNat, TokenSaleMetadata, Mem>> =
         RefCell::new(StableBTreeMap::init(MEM_MGR.with(|m| m.borrow().get(MemoryId::new(5)))));
+
+    static LISTINGS: RefCell<StableBTreeMap<SListingId, ListingRecord, Mem>> =
+        RefCell::new(StableBTreeMap::init(MEM_MGR.with(|m| m.borrow().get(MemoryId::new(6)))));
+
+    static TOKEN_LISTING_INDEX: RefCell<StableBTreeMap<SNat, SListingId, Mem>> =
+        RefCell::new(StableBTreeMap::init(MEM_MGR.with(|m| m.borrow().get(MemoryId::new(7)))));
+
+    static LISTING_SEQ: RefCell<StableBTreeMap<u8, ListingCounter, Mem>> =
+        RefCell::new(StableBTreeMap::init(MEM_MGR.with(|m| m.borrow().get(MemoryId::new(8)))));
 }
 
 // ---------- Init ----------
@@ -270,7 +454,7 @@ fn init(args: Option<InitArgs>) {
         st.description = args.as_ref().and_then(|a| a.description.clone());
         st.logo = args.as_ref().and_then(|a| a.logo.clone());
         st.admin = args.as_ref().and_then(|a| a.admin).unwrap_or(caller);
-        st.total_supply = Nat::from(0u32);
+        st.total_supply = 0u128;
         st.created_at = time();
     });
 
@@ -302,7 +486,7 @@ pub fn icrc7_symbol() -> String {
 
 #[query(name = "icrc7_total_supply")]
 pub fn icrc7_total_supply() -> Nat {
-    STATE.with(|s| s.borrow().total_supply.clone())
+    STATE.with(|s| Nat::from(s.borrow().total_supply))
 }
 
 #[query(name = "icrc7_supported_standards")]
@@ -347,7 +531,14 @@ pub fn get_token(token_id: Nat) -> Option<TokenRecord> {
 
 #[query]
 pub fn get_token_by_meme_id(meme_id: u64) -> Option<Nat> {
-    MINT_INDEX.with(|m| m.borrow().get(&meme_id).map(|sn| sn.0))
+    MINT_INDEX.with(|m| {
+        m.borrow()
+            .get(&meme_id)
+            .and_then(|info| match &info.status {
+                MintingStatus::Single { token_id, .. } => Some(token_id.clone()),
+                MintingStatus::Collection { token_ids, .. } => token_ids.first().cloned(),
+            })
+    })
 }
 
 #[query]
@@ -391,20 +582,103 @@ where
             });
         record.token_id = token_id.clone();
         record.meme_id = meme_id;
+        record.current_owner =
+            TOKENS.with(|t| t.borrow().get(&SNat(token_id.clone())).map(|rec| rec.owner));
         let mut_record = &mut record;
         mutator(mut_record);
+        if record.is_listed {
+            record.floor_price = match record.floor_price {
+                Some(existing) => Some(existing.min(record.listing_price.unwrap_or(existing))),
+                None => record.listing_price,
+            };
+        }
         map.insert(SNat(token_id.clone()), record.clone());
         record
     })
+}
+
+fn collect_sale_metadata(token_ids: &[Nat]) -> Vec<TokenSaleMetadata> {
+    TOKEN_SALES.with(|sales| {
+        let map = sales.borrow();
+        token_ids
+            .iter()
+            .filter_map(|token_id| map.get(&SNat(token_id.clone())))
+            .collect()
+    })
+}
+
+fn aggregate_market_info(token_ids: &[Nat]) -> NftMarketInfo {
+    let sales = collect_sale_metadata(token_ids);
+    let mut info = NftMarketInfo::default();
+    let mut latest_sale_ts: Option<u64> = None;
+
+    for sale in sales {
+        if sale.is_listed {
+            info.listed = true;
+            if let Some(price) = sale.listing_price {
+                info.listing_price = Some(match info.listing_price {
+                    Some(existing) => existing.min(price),
+                    None => price,
+                });
+            }
+            info.listed_quantity = info.listed_quantity.saturating_add(sale.listed_quantity);
+        }
+
+        info.total_volume = info.total_volume.saturating_add(sale.total_volume);
+        info.total_sales = info.total_sales.saturating_add(sale.total_sales);
+
+        if let Some(floor) = sale.floor_price {
+            info.floor_price = Some(match info.floor_price {
+                Some(existing) => existing.min(floor),
+                None => floor,
+            });
+        }
+
+        if let Some(rank) = sale.ranking_hint {
+            info.ranking = Some(match info.ranking {
+                Some(existing) => existing.min(rank),
+                None => rank,
+            });
+        }
+
+        if let Some(price) = sale.last_sale_price {
+            let ts = sale.last_sale_at.unwrap_or_default();
+            match latest_sale_ts {
+                Some(existing) if ts <= existing => {}
+                _ => {
+                    latest_sale_ts = Some(ts);
+                    info.last_sale_price = Some(price);
+                    info.last_sale_at = sale.last_sale_at;
+                }
+            }
+        }
+
+        if info.current_owner.is_none() {
+            info.current_owner = sale.current_owner;
+        }
+    }
+
+    info
 }
 
 // ---------- Internal helpers ----------
 fn next_token_id() -> Nat {
     STATE.with(|s| {
         let mut st = s.borrow_mut();
-        let tid = st.total_supply.clone();
-        st.total_supply = st.total_supply.clone() + Nat::from(1u32);
-        tid
+        let tid = st.total_supply;
+        st.total_supply = st.total_supply.saturating_add(1);
+        Nat::from(tid)
+    })
+}
+
+fn next_listing_id() -> ListingId {
+    LISTING_SEQ.with(|seq| {
+        let mut map = seq.borrow_mut();
+        let mut counter = map.get(&0).unwrap_or(ListingCounter(0));
+        let id = counter.0;
+        counter.0 = counter.0.saturating_add(1);
+        map.insert(0, counter.clone());
+        id
     })
 }
 
@@ -414,6 +688,16 @@ fn push_owner(owner: Principal, token_id: &Nat) {
         let mut list = map.get(&SPrincipal(owner)).unwrap_or_default();
         list.0.push(token_id.clone());
         map.insert(SPrincipal(owner), list);
+    });
+}
+
+fn remove_owner_token(owner: Principal, token_id: &Nat) {
+    OWNER_INDEX.with(|idx| {
+        let mut map = idx.borrow_mut();
+        if let Some(mut list) = map.get(&SPrincipal(owner)) {
+            list.0.retain(|t| t != token_id);
+            map.insert(SPrincipal(owner), list);
+        }
     });
 }
 
@@ -498,6 +782,186 @@ fn build_metadata(m: &PublicStoredMeme, token_id: &Nat) -> Vec<TokenMetadataEntr
     root
 }
 
+fn enrich_with_custom_metadata(
+    base: &mut Vec<TokenMetadataEntry>,
+    custom: &NftMetadata,
+    edition_number: Option<u32>,
+    edition_size: Option<u32>,
+) {
+    base.push(TokenMetadataEntry {
+        name: "nft:name".into(),
+        immutable: true,
+        value: MetadataValue::Text(custom.name.clone()),
+    });
+    base.push(TokenMetadataEntry {
+        name: "nft:symbol".into(),
+        immutable: true,
+        value: MetadataValue::Text(custom.symbol.clone()),
+    });
+    if let Some(desc) = &custom.description {
+        base.push(TokenMetadataEntry {
+            name: "nft:description".into(),
+            immutable: false,
+            value: MetadataValue::Text(desc.clone()),
+        });
+    }
+    if let Some(royalty) = custom.royalty_bps {
+        base.push(TokenMetadataEntry {
+            name: "nft:royalty_bps".into(),
+            immutable: true,
+            value: MetadataValue::Text(royalty.to_string()),
+        });
+    }
+    if let Some(url) = &custom.external_url {
+        base.push(TokenMetadataEntry {
+            name: "nft:external_url".into(),
+            immutable: false,
+            value: MetadataValue::Text(url.clone()),
+        });
+    }
+    if let Some(license) = &custom.license {
+        base.push(TokenMetadataEntry {
+            name: "nft:license".into(),
+            immutable: false,
+            value: MetadataValue::Text(license.clone()),
+        });
+    }
+
+    if !custom.attributes.is_empty() {
+        base.push(TokenMetadataEntry {
+            name: "nft:attributes".into(),
+            immutable: false,
+            value: MetadataValue::Map(
+                custom
+                    .attributes
+                    .iter()
+                    .map(|(k, v)| (k.clone(), MetadataValue::Text(v.clone())))
+                    .collect(),
+            ),
+        });
+    }
+
+    base.push(TokenMetadataEntry {
+        name: "nft:image_uri".into(),
+        immutable: true,
+        value: MetadataValue::Text(custom.image_uri.clone()),
+    });
+
+    if let Some(number) = edition_number {
+        base.push(TokenMetadataEntry {
+            name: "nft:edition_number".into(),
+            immutable: true,
+            value: MetadataValue::Text(number.to_string()),
+        });
+    }
+
+    if let Some(size) = edition_size {
+        base.push(TokenMetadataEntry {
+            name: "nft:edition_size".into(),
+            immutable: true,
+            value: MetadataValue::Text(size.to_string()),
+        });
+    }
+}
+
+fn token_is_locked(token_id: &Nat) -> bool {
+    TOKEN_LISTING_INDEX.with(|idx| idx.borrow().get(&SNat(token_id.clone())).is_some())
+}
+
+fn lock_tokens(listing_id: ListingId, token_ids: &[Nat]) {
+    TOKEN_LISTING_INDEX.with(|idx| {
+        let mut map = idx.borrow_mut();
+        for token_id in token_ids {
+            map.insert(SNat(token_id.clone()), SListingId(listing_id));
+        }
+    });
+}
+
+fn unlock_tokens(token_ids: &[Nat]) {
+    TOKEN_LISTING_INDEX.with(|idx| {
+        let mut map = idx.borrow_mut();
+        for token_id in token_ids {
+            map.remove(&SNat(token_id.clone()));
+        }
+    });
+}
+
+fn metadata_for_meme(meme_id: MemeId) -> Option<(NftMetadata, Vec<Nat>, bool, Option<u32>)> {
+    MINT_INDEX.with(|index| {
+        index.borrow().get(&meme_id).map(|info| match &info.status {
+            MintingStatus::Single { token_id, metadata } => {
+                (metadata.clone(), vec![token_id.clone()], false, None)
+            }
+            MintingStatus::Collection {
+                token_ids,
+                edition_size,
+                metadata,
+            } => (
+                metadata.clone(),
+                token_ids.clone(),
+                true,
+                Some(*edition_size),
+            ),
+        })
+    })
+}
+
+fn owned_unlocked_tokens(meme_id: MemeId, owner: Principal) -> Vec<Nat> {
+    MINT_INDEX.with(|index| {
+        index
+            .borrow()
+            .get(&meme_id)
+            .map(|info| match info.status {
+                MintingStatus::Single { ref token_id, .. } => {
+                    let is_owner = TOKENS
+                        .with(|t| t.borrow().get(&SNat(token_id.clone())).map(|rec| rec.owner))
+                        .map(|principal| principal == owner)
+                        .unwrap_or(false);
+                    if is_owner && !token_is_locked(token_id) {
+                        vec![token_id.clone()]
+                    } else {
+                        vec![]
+                    }
+                }
+                MintingStatus::Collection { ref token_ids, .. } => token_ids
+                    .iter()
+                    .filter(|tid| {
+                        TOKENS
+                            .with(|t| t.borrow().get(&SNat((*tid).clone())).map(|rec| rec.owner))
+                            .map(|principal| principal == owner)
+                            .unwrap_or(false)
+                            && !token_is_locked(tid)
+                    })
+                    .cloned()
+                    .collect(),
+            })
+            .unwrap_or_default()
+    })
+}
+
+fn acquire_tokens_for_listing(
+    meme_id: MemeId,
+    owner: Principal,
+    count: u32,
+) -> Result<Vec<Nat>, String> {
+    let available = owned_unlocked_tokens(meme_id, owner);
+    if count as usize > available.len() {
+        return Err("Insufficient quantity owned".into());
+    }
+    Ok(available.into_iter().take(count as usize).collect())
+}
+
+fn mark_tokens_unlisted(meme_id: MemeId, tokens: &[Nat]) {
+    for token_id in tokens {
+        mutate_sale_metadata(token_id, meme_id, |sale| {
+            sale.is_listed = false;
+            sale.listing_price = None;
+            sale.listed_quantity = 0;
+        });
+    }
+    unlock_tokens(tokens);
+}
+
 // ---------- X-canister clients ----------
 async fn voting_get_top3_for_week(
     voting_canister: Principal,
@@ -525,34 +989,21 @@ async fn voting_get_meme_data(
         .map_err(|e| format!("get_meme call failed: {:?}", e))
 }
 
-// ---------- Public: mint Top-3 (now fetches image bytes before minting) ----------
-#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
-pub struct MintedPair {
-    pub meme_id: u64,
-    pub token_id: Nat,
-    pub owner: Principal,
-}
+async fn ensure_image_cached(meme: &PublicStoredMeme) -> Result<String, String> {
+    let meme_id = meme.id;
+    let mime_type = guess_content_type(&meme.meme_data.image_format)
+        .unwrap_or_else(|| "application/octet-stream".into());
 
-#[update]
-async fn mint_to(meme_id: u64) -> Result<Nat, String> {
-    // Prevent double-minting for same meme
-    if let Some(existing) = MINT_INDEX.with(|mi| mi.borrow().get(&meme_id)) {
-        return Ok(existing.0);
+    let already_cached = STORED_IMAGES.with(|imgs| imgs.borrow().contains_key(&meme_id));
+    if already_cached {
+        return Ok(mime_type);
     }
 
-    let voting_canister = ic_cdk::api::id();
-    let stored_meme_data = voting_get_meme_data(voting_canister, meme_id)
-        .await?
-        .ok_or_else(|| format!("StoredMeme {} not found in voting canister", meme_id))?;
-
-    let image_url = stored_meme_data.meme_data.image_url.clone();
-    let image_format = stored_meme_data.meme_data.image_format.clone();
-    let mime_type =
-        guess_content_type(&image_format).unwrap_or_else(|| "application/octet-stream".into());
-
     let image_bytes =
-        match crate::http_outcall::fetch_image_bytes_from_image_storage(&image_url).await {
-            Ok(b) => b,
+        match crate::http_outcall::fetch_image_bytes_from_image_storage(&meme.meme_data.image_url)
+            .await
+        {
+            Ok(bytes) => bytes,
             Err(e) => {
                 return Err(format!(
                     "failed to fetch image for meme {} : {}",
@@ -561,39 +1012,238 @@ async fn mint_to(meme_id: u64) -> Result<Nat, String> {
             }
         };
 
-    // Store image bytes in STORED_IMAGES under meme_id
     STORED_IMAGES.with(|imgs| {
         imgs.borrow_mut().insert(meme_id, ImageBlob(image_bytes));
     });
 
-    // Generate token_id and build token metadata
-    let token_id = next_token_id();
-    let mut metadata = build_metadata(&stored_meme_data, &token_id);
+    Ok(mime_type)
+}
 
-    // Add content type to metadata (ensures downstream clients can read content type)
-    metadata.push(TokenMetadataEntry {
-        name: "icrc7:metadata:content_type".into(),
-        immutable: true,
-        value: MetadataValue::Text(mime_type.clone()),
-    });
+// ---------- Public: mint Top-3 (now fetches image bytes before minting) ----------
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct MintedPair {
+    pub meme_id: u64,
+    pub token_id: Nat,
+    pub owner: Principal,
+}
 
-    let rec = TokenRecord {
-        token_id: token_id.clone(),
-        owner: stored_meme_data.owner,
-        minted_at: ic_cdk::api::time(),
-        meme_id,
-        metadata,
-        mime_type: Some(mime_type),
-        has_image: true,
+async fn mint_tokens_internal(
+    meme: &PublicStoredMeme,
+    owner: Principal,
+    minted_by: Principal,
+    metadata: &NftMetadata,
+    edition_count: u32,
+) -> Result<Vec<Nat>, String> {
+    if edition_count == 0 {
+        return Err("Edition count must be greater than zero".into());
+    }
+
+    if MINT_INDEX.with(|index| index.borrow().contains_key(&meme.id)) {
+        return Err("Meme has already been minted".into());
+    }
+
+    let mime_type = ensure_image_cached(meme).await?;
+    let minted_at = ic_cdk::api::time();
+    let ranking_hint = crate::voting::get_rank_for_meme(meme.id);
+
+    let mut minted_tokens = Vec::new();
+    for edition in 0..edition_count {
+        let token_id = next_token_id();
+        let mut token_metadata = build_metadata(meme, &token_id);
+        token_metadata.push(TokenMetadataEntry {
+            name: "icrc7:metadata:content_type".into(),
+            immutable: true,
+            value: MetadataValue::Text(mime_type.clone()),
+        });
+        enrich_with_custom_metadata(
+            &mut token_metadata,
+            metadata,
+            if edition_count > 1 {
+                Some(edition + 1)
+            } else {
+                None
+            },
+            if edition_count > 1 {
+                Some(edition_count)
+            } else {
+                None
+            },
+        );
+
+        let record = TokenRecord {
+            token_id: token_id.clone(),
+            owner,
+            minted_at,
+            meme_id: meme.id,
+            metadata: token_metadata,
+            mime_type: Some(mime_type.clone()),
+            has_image: true,
+            minted_by,
+            edition_number: if edition_count > 1 {
+                Some(edition + 1)
+            } else {
+                None
+            },
+            edition_size: if edition_count > 1 {
+                Some(edition_count)
+            } else {
+                None
+            },
+            custom_metadata: Some(metadata.clone()),
+        };
+
+        TOKENS.with(|t| t.borrow_mut().insert(SNat(token_id.clone()), record));
+        push_owner(owner, &token_id);
+        mutate_sale_metadata(&token_id, meme.id, |sale| {
+            sale.current_owner = Some(owner);
+            sale.ranking_hint = ranking_hint;
+        });
+
+        minted_tokens.push(token_id);
+    }
+
+    let status = if edition_count == 1 {
+        MintingStatus::Single {
+            token_id: minted_tokens
+                .first()
+                .cloned()
+                .unwrap_or_else(|| Nat::from(0u32)),
+            metadata: metadata.clone(),
+        }
+    } else {
+        MintingStatus::Collection {
+            token_ids: minted_tokens.clone(),
+            edition_size: edition_count,
+            metadata: metadata.clone(),
+        }
     };
 
-    // Persist token record and indexes
-    TOKENS.with(|t| t.borrow_mut().insert(SNat(token_id.clone()), rec));
-    push_owner(stored_meme_data.owner, &token_id);
-    MINT_INDEX.with(|mi| mi.borrow_mut().insert(meme_id, SNat(token_id.clone())));
-    mutate_sale_metadata(&token_id, meme_id, |_| {});
+    MINT_INDEX.with(|index| {
+        index.borrow_mut().insert(
+            meme.id,
+            MintingInfo {
+                meme_id: meme.id,
+                minted_by,
+                minted_at,
+                status,
+            },
+        );
+    });
 
-    Ok(token_id)
+    Ok(minted_tokens)
+}
+
+#[update]
+async fn mint_to(meme_id: u64) -> Result<Nat, String> {
+    // Legacy helper kept for compatibility with existing finalize flow.
+    let voting_canister = ic_cdk::api::id();
+    let stored_meme_data = voting_get_meme_data(voting_canister, meme_id)
+        .await?
+        .ok_or_else(|| format!("StoredMeme {} not found in voting canister", meme_id))?;
+
+    let auto_meta = NftMetadata {
+        name: format!("Mementic Meme #{}", meme_id),
+        symbol: "MEME".into(),
+        description: stored_meme_data
+            .meme_data
+            .caption
+            .clone()
+            .or_else(|| Some("Weekly winner meme".into())),
+        royalty_bps: Some(0),
+        external_url: Some(stored_meme_data.meme_data.image_url.clone()),
+        attributes: vec![
+            ("prompt".into(), stored_meme_data.meme_data.prompt.clone()),
+            (
+                "service".into(),
+                stored_meme_data.meme_data.metadata.service.clone(),
+            ),
+        ],
+        license: None,
+        image_uri: stored_meme_data.meme_data.image_url.clone(),
+    };
+
+    let token_ids = mint_tokens_internal(
+        &stored_meme_data,
+        stored_meme_data.owner,
+        stored_meme_data.owner,
+        &auto_meta,
+        1,
+    )
+    .await?;
+    Ok(token_ids
+        .first()
+        .cloned()
+        .unwrap_or_else(|| Nat::from(0u32)))
+}
+
+#[update]
+pub async fn mint_single_nft(meme_id: MemeId, meta: NftMetadata) -> Result<Nat, String> {
+    let caller = ic_cdk::caller();
+    if caller == Principal::anonymous() {
+        return Err("Authentication required".into());
+    }
+
+    if !crate::voting::is_winner(meme_id) {
+        return Err("Only weekly winners can be minted".into());
+    }
+
+    if MINT_INDEX.with(|index| index.borrow().contains_key(&meme_id)) {
+        return Err("Meme has already been minted".into());
+    }
+
+    let meme = crate::get_meme(meme_id).ok_or("Meme not found")?;
+    if meme.owner != caller {
+        return Err("Only the meme owner can mint".into());
+    }
+
+    if meta.name.trim().is_empty() {
+        return Err("NFT name is required".into());
+    }
+
+    let token_ids = mint_tokens_internal(&meme, caller, caller, &meta, 1).await?;
+    Ok(token_ids
+        .first()
+        .cloned()
+        .unwrap_or_else(|| Nat::from(0u32)))
+}
+
+#[update]
+pub async fn mint_collection_nft(
+    meme_id: MemeId,
+    edition_count: u32,
+    meta: NftMetadata,
+) -> Result<Vec<Nat>, String> {
+    let caller = ic_cdk::caller();
+    if caller == Principal::anonymous() {
+        return Err("Authentication required".into());
+    }
+
+    if edition_count == 0 {
+        return Err("Edition count must be at least 1".into());
+    }
+
+    if edition_count > 10_000 {
+        return Err("Edition count too large".into());
+    }
+
+    if !crate::voting::is_winner(meme_id) {
+        return Err("Only weekly winners can be minted".into());
+    }
+
+    if MINT_INDEX.with(|index| index.borrow().contains_key(&meme_id)) {
+        return Err("Meme has already been minted".into());
+    }
+
+    let meme = crate::get_meme(meme_id).ok_or("Meme not found")?;
+    if meme.owner != caller {
+        return Err("Only the meme owner can mint".into());
+    }
+
+    if meta.name.trim().is_empty() {
+        return Err("NFT name is required".into());
+    }
+
+    mint_tokens_internal(&meme, caller, caller, &meta, edition_count).await
 }
 
 #[update]
@@ -626,4 +1276,413 @@ pub async fn mint_week_top3_from_voting(week_id: u64) -> Result<Vec<MintedPair>,
 
     WEEK_MINTED.with(|wm| wm.borrow_mut().insert(week_id, true));
     Ok(minted)
+}
+
+#[query]
+pub fn my_minted_nfts(owner: Option<Principal>) -> Vec<NftSummary> {
+    let target = owner.unwrap_or_else(ic_cdk::caller);
+    if target == Principal::anonymous() {
+        return vec![];
+    }
+
+    MINT_INDEX.with(|index| {
+        index
+            .borrow()
+            .iter()
+            .filter_map(|entry| {
+                let info = entry.value();
+                if info.minted_by != target {
+                    return None;
+                }
+
+                match &info.status {
+                    MintingStatus::Single { token_id, metadata } => {
+                        let owned = TOKENS
+                            .with(|t| t.borrow().get(&SNat(token_id.clone())))
+                            .map(|rec| if rec.owner == target { 1 } else { 0 })
+                            .unwrap_or(0);
+                        let market = aggregate_market_info(&[token_id.clone()]);
+                        Some(NftSummary {
+                            meme_id: info.meme_id,
+                            token_id: token_id.clone(),
+                            name: metadata.name.clone(),
+                            image_uri: metadata.image_uri.clone(),
+                            is_collection: false,
+                            edition_size: None,
+                            owned_quantity: owned,
+                            market,
+                        })
+                    }
+                    MintingStatus::Collection {
+                        token_ids,
+                        edition_size,
+                        metadata,
+                    } => {
+                        let owned = token_ids
+                            .iter()
+                            .filter(|tid| {
+                                TOKENS
+                                    .with(|t| {
+                                        t.borrow().get(&SNat((**tid).clone())).map(|rec| rec.owner)
+                                    })
+                                    .map(|principal| principal == target)
+                                    .unwrap_or(false)
+                            })
+                            .count() as u32;
+                        let first_token = token_ids
+                            .first()
+                            .cloned()
+                            .unwrap_or_else(|| Nat::from(0u32));
+                        let market = aggregate_market_info(token_ids);
+                        Some(NftSummary {
+                            meme_id: info.meme_id,
+                            token_id: first_token,
+                            name: metadata.name.clone(),
+                            image_uri: metadata.image_uri.clone(),
+                            is_collection: true,
+                            edition_size: Some(*edition_size),
+                            owned_quantity: owned,
+                            market,
+                        })
+                    }
+                }
+            })
+            .collect()
+    })
+}
+
+fn assert_token_owner(token_id: &Nat, owner: Principal) -> Result<TokenRecord, String> {
+    TOKENS
+        .with(|t| t.borrow().get(&SNat(token_id.clone())))
+        .ok_or_else(|| "Token not found".into())
+        .and_then(|record| {
+            if record.owner != owner {
+                Err("Caller does not own the requested token".into())
+            } else {
+                Ok(record)
+            }
+        })
+}
+
+fn refresh_listing_metadata(record: &ListingRecord) {
+    for token_id in &record.locked_token_ids {
+        mutate_sale_metadata(token_id, record.meme_id, |sale| {
+            if record.listing.active {
+                sale.is_listed = true;
+                sale.listing_price = Some(record.listing.unit_price);
+                sale.listed_quantity = record.listing.quantity;
+                sale.listed_at = Some(record.listing.created_at_ns);
+            } else {
+                sale.is_listed = false;
+                sale.listing_price = None;
+                sale.listed_quantity = 0;
+            }
+        });
+    }
+}
+
+#[update]
+pub fn list_for_sale(
+    token_id: Nat,
+    unit_price: u128,
+    quantity: u32,
+    expires_at_ns: Option<u64>,
+) -> Result<ListingId, String> {
+    let caller = ic_cdk::caller();
+    if caller == Principal::anonymous() {
+        return Err("Authentication required".into());
+    }
+    if unit_price == 0 {
+        return Err("Price must be greater than zero".into());
+    }
+    if quantity == 0 {
+        return Err("Quantity must be at least one".into());
+    }
+
+    let token = assert_token_owner(&token_id, caller.clone())?;
+    if token_is_locked(&token_id) {
+        return Err("Token already listed".into());
+    }
+
+    let available_tokens = owned_unlocked_tokens(token.meme_id, caller);
+    let is_collection = token.edition_size.unwrap_or(1) > 1;
+
+    let selected: Vec<Nat> = if is_collection {
+        if quantity as usize > available_tokens.len() {
+            return Err("Insufficient quantity owned".into());
+        }
+        available_tokens
+            .into_iter()
+            .take(quantity as usize)
+            .collect()
+    } else {
+        if quantity != 1 {
+            return Err("Single NFT listings must use quantity 1".into());
+        }
+        if !available_tokens.iter().any(|tid| tid == &token_id) {
+            return Err("Token is not available to list".into());
+        }
+        vec![token_id.clone()]
+    };
+
+    let listing_id = next_listing_id();
+    let now = ic_cdk::api::time();
+    let listing = Listing {
+        listing_id,
+        token_id: token_id.clone(),
+        seller: ic_cdk::caller(),
+        unit_price,
+        quantity: selected.len() as u32,
+        created_at_ns: now,
+        expires_at_ns,
+        active: true,
+    };
+
+    let record = ListingRecord {
+        listing,
+        meme_id: token.meme_id,
+        locked_token_ids: selected.clone(),
+    };
+
+    LISTINGS.with(|listings| {
+        listings
+            .borrow_mut()
+            .insert(SListingId(listing_id), record.clone());
+    });
+
+    lock_tokens(listing_id, &selected);
+    refresh_listing_metadata(&record);
+
+    Ok(listing_id)
+}
+
+#[update]
+pub fn update_listing(
+    listing_id: ListingId,
+    new_unit_price: Option<u128>,
+    new_quantity: Option<u32>,
+    new_expires_at_ns: Option<u64>,
+) -> Result<(), String> {
+    let caller = ic_cdk::caller();
+    LISTINGS.with(|listings| {
+        let mut map = listings.borrow_mut();
+        let mut record = map
+            .get(&SListingId(listing_id))
+            .ok_or_else(|| "Listing not found".to_string())?;
+
+        if record.listing.seller != caller {
+            return Err("Only the seller can update the listing".into());
+        }
+        if !record.listing.active {
+            return Err("Listing is no longer active".into());
+        }
+
+        if let Some(price) = new_unit_price {
+            if price == 0 {
+                return Err("Price must be greater than zero".into());
+            }
+            record.listing.unit_price = price;
+        }
+
+        if let Some(expiry) = new_expires_at_ns {
+            record.listing.expires_at_ns = Some(expiry);
+        }
+
+        if let Some(qty) = new_quantity {
+            if qty == 0 {
+                return Err("Quantity must be at least one".into());
+            }
+
+            if qty < record.listing.quantity {
+                let to_release = (record.listing.quantity - qty) as usize;
+                let released = record
+                    .locked_token_ids
+                    .split_off(record.locked_token_ids.len() - to_release);
+                mark_tokens_unlisted(record.meme_id, &released);
+                record.listing.quantity = qty;
+            } else if qty > record.listing.quantity {
+                let additional = qty - record.listing.quantity;
+                let extra_tokens = acquire_tokens_for_listing(record.meme_id, caller, additional)?;
+                lock_tokens(listing_id, &extra_tokens);
+                record.locked_token_ids.extend(extra_tokens);
+                record.listing.quantity = qty;
+            }
+        }
+
+        refresh_listing_metadata(&record);
+        map.insert(SListingId(listing_id), record);
+        Ok(())
+    })
+}
+
+#[update]
+pub fn cancel_listing(listing_id: ListingId) -> Result<(), String> {
+    let caller = ic_cdk::caller();
+    LISTINGS.with(|listings| {
+        let mut map = listings.borrow_mut();
+        let mut record = map
+            .get(&SListingId(listing_id))
+            .ok_or_else(|| "Listing not found".to_string())?;
+
+        if record.listing.seller != caller {
+            return Err("Only the seller can cancel the listing".into());
+        }
+        if !record.listing.active {
+            return Ok(());
+        }
+
+        record.listing.active = false;
+        record.listing.quantity = 0;
+        mark_tokens_unlisted(record.meme_id, &record.locked_token_ids);
+        record.locked_token_ids.clear();
+        refresh_listing_metadata(&record);
+        map.insert(SListingId(listing_id), record);
+        Ok(())
+    })
+}
+
+fn transfer_token(token_id: &Nat, from: Principal, to: Principal, meme_id: MemeId) {
+    TOKENS.with(|tokens| {
+        let mut map = tokens.borrow_mut();
+        if let Some(mut rec) = map.get(&SNat(token_id.clone())) {
+            rec.owner = to;
+            map.insert(SNat(token_id.clone()), rec);
+        }
+    });
+    remove_owner_token(from, token_id);
+    push_owner(to, token_id);
+    mutate_sale_metadata(token_id, meme_id, |sale| {
+        sale.current_owner = Some(to);
+        sale.is_listed = false;
+        sale.listing_price = None;
+        sale.listed_quantity = 0;
+        sale.total_sales = sale.total_sales.saturating_add(1);
+    });
+}
+
+#[update]
+pub fn buy(listing_id: ListingId, quantity: u32) -> Result<(), String> {
+    if quantity == 0 {
+        return Err("Quantity must be at least one".into());
+    }
+    let buyer = ic_cdk::caller();
+    if buyer == Principal::anonymous() {
+        return Err("Authentication required".into());
+    }
+
+    LISTINGS.with(|listings| {
+        let mut map = listings.borrow_mut();
+        let mut record = map
+            .get(&SListingId(listing_id))
+            .ok_or_else(|| "Listing not found".to_string())?;
+
+        if !record.listing.active {
+            return Err("Listing is no longer active".into());
+        }
+
+        if let Some(expiry) = record.listing.expires_at_ns {
+            if ic_cdk::api::time() > expiry {
+                record.listing.active = false;
+                mark_tokens_unlisted(record.meme_id, &record.locked_token_ids);
+                record.locked_token_ids.clear();
+                map.insert(SListingId(listing_id), record);
+                return Err("Listing has expired".into());
+            }
+        }
+
+        if quantity > record.listing.quantity {
+            return Err("Not enough quantity remaining".into());
+        }
+
+        let seller = record.listing.seller;
+        if buyer == seller {
+            return Err("Cannot purchase your own listing".into());
+        }
+
+        let now = ic_cdk::api::time();
+        let mut transferred = Vec::new();
+        for _ in 0..quantity {
+            if let Some(token_id) = record.locked_token_ids.pop() {
+                transfer_token(&token_id, seller, buyer, record.meme_id);
+                TOKEN_LISTING_INDEX.with(|idx| idx.borrow_mut().remove(&SNat(token_id.clone())));
+                mutate_sale_metadata(&token_id, record.meme_id, |sale| {
+                    sale.last_sale_at = Some(now);
+                    sale.last_sale_price = Some(record.listing.unit_price);
+                    sale.total_earned = sale.total_earned.saturating_add(record.listing.unit_price);
+                    sale.total_volume = sale.total_volume.saturating_add(record.listing.unit_price);
+                });
+                transferred.push(token_id);
+            }
+        }
+
+        record.listing.quantity = record.listing.quantity.saturating_sub(quantity);
+        if record.listing.quantity == 0 {
+            record.listing.active = false;
+        }
+
+        refresh_listing_metadata(&record);
+        map.insert(SListingId(listing_id), record);
+
+        Ok(())
+    })
+}
+
+fn collect_active_listings() -> Vec<ListingRecord> {
+    LISTINGS.with(|listings| {
+        listings
+            .borrow()
+            .iter()
+            .filter_map(|entry| {
+                let record = entry.value();
+                if !record.listing.active {
+                    return None;
+                }
+                if let Some(expiry) = record.listing.expires_at_ns {
+                    if ic_cdk::api::time() > expiry {
+                        return None;
+                    }
+                }
+                Some(record)
+            })
+            .collect()
+    })
+}
+
+fn build_marketplace_listing(record: &ListingRecord) -> Option<MarketplaceListing> {
+    let (metadata, token_ids, is_collection, edition_size) = metadata_for_meme(record.meme_id)?;
+    let market = aggregate_market_info(&token_ids);
+    Some(MarketplaceListing {
+        listing: record.listing.clone(),
+        meme_id: record.meme_id,
+        name: metadata.name,
+        image_uri: metadata.image_uri,
+        is_collection,
+        edition_size,
+        market,
+    })
+}
+
+#[query]
+pub fn show_all_nfts_for_sale(offset: u64, limit: u32) -> Vec<MarketplaceListing> {
+    let listings = collect_active_listings();
+    let start = offset as usize;
+    listings
+        .into_iter()
+        .skip(start)
+        .take(limit as usize)
+        .filter_map(|record| build_marketplace_listing(&record))
+        .collect()
+}
+
+#[query]
+pub fn get_user_listings(user: Option<Principal>) -> Vec<MarketplaceListing> {
+    let target = user.unwrap_or_else(ic_cdk::caller);
+    if target == Principal::anonymous() {
+        return vec![];
+    }
+    collect_active_listings()
+        .into_iter()
+        .filter(|record| record.listing.seller == target)
+        .filter_map(|record| build_marketplace_listing(&record))
+        .collect()
 }

--- a/src/Mementic_frontend/src/Pages/Marketplace.jsx
+++ b/src/Mementic_frontend/src/Pages/Marketplace.jsx
@@ -14,6 +14,8 @@ import {
 import { Button } from "../components/ui/Button";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/Card";
 import Navigation from "../components/Navigation";
+import backendService from "../services/backendService";
+import { useToast } from "../hooks/use-toast";
 
 const trendingMemes = [];
 
@@ -29,9 +31,32 @@ const slideVariants = {
   exit: { opacity: 0, scale: 0.96, y: -12 },
 };
 
+const unwrapOptional = (value) => (Array.isArray(value) ? value[0] : value);
+
+const formatPrincipalId = (principal) => {
+  if (!principal) return "-";
+  const text = principal?.toText?.() ?? principal?.toString?.() ?? String(principal);
+  if (text.length <= 10) return text;
+  return `${text.slice(0, 5)}...${text.slice(-3)}`;
+};
+
+const formatRanking = (rank) => {
+  const value = unwrapOptional(rank);
+  if (value === undefined || value === null) return "Unranked";
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return "Unranked";
+  }
+  return `#${numeric}`;
+};
+
 const Marketplace = () => {
   const [currentSlide, setCurrentSlide] = useState(0);
   const totalSlides = trendingMemes.length;
+  const [marketListings, setMarketListings] = useState([]);
+  const [loadingListings, setLoadingListings] = useState(true);
+  const [buyingId, setBuyingId] = useState(null);
+  const { toast } = useToast();
 
   useEffect(() => {
     if (totalSlides > 1) {
@@ -41,6 +66,26 @@ const Marketplace = () => {
       return () => clearInterval(id);
     }
   }, [totalSlides]);
+
+  useEffect(() => {
+    const loadListings = async () => {
+      try {
+        await backendService.ensureReady();
+        const listings = await backendService.getMarketplaceListings(0, 20);
+        setMarketListings(listings);
+      } catch (error) {
+        console.error("Failed to load marketplace listings", error);
+        toast({
+          title: "Marketplace unavailable",
+          description: error.message ?? String(error),
+          variant: "destructive",
+        });
+      } finally {
+        setLoadingListings(false);
+      }
+    };
+    loadListings();
+  }, [toast]);
 
   const currentMeme = useMemo(
     () => trendingMemes[currentSlide] ?? trendingMemes[0],
@@ -54,6 +99,55 @@ const Marketplace = () => {
       }
       return (prev - 1 + totalSlides) % totalSlides;
     });
+  };
+
+  const formatPrice = (value) => {
+    if (value === undefined || value === null) return "-";
+    const nat = typeof value === "bigint" ? value : BigInt(value);
+    const whole = nat / 100000000n;
+    const fraction = nat % 100000000n;
+    const fracStr = fraction.toString().padStart(8, "0").replace(/0+$/, "");
+    return `${whole}${fracStr ? `.${fracStr}` : ""} ICP`;
+  };
+
+  const refreshListings = async () => {
+    setLoadingListings(true);
+    try {
+      const listings = await backendService.getMarketplaceListings(0, 20);
+      setMarketListings(listings);
+    } catch (error) {
+      console.error("Failed to refresh listings", error);
+      toast({
+        title: "Refresh failed",
+        description: error.message ?? String(error),
+        variant: "destructive",
+      });
+    } finally {
+      setLoadingListings(false);
+    }
+  };
+
+  const handleBuy = async (listing) => {
+    try {
+      const id = listing.listing?.listing_id ?? listing.listing_id;
+      const idText = id?.toString?.() ?? String(id);
+      setBuyingId(idText);
+      await backendService.buyFromListing(id, 1);
+      toast({
+        title: "Purchase successful",
+        description: "NFT purchased successfully.",
+      });
+      await refreshListings();
+    } catch (error) {
+      console.error("Purchase failed", error);
+      toast({
+        title: "Purchase failed",
+        description: error.message ?? String(error),
+        variant: "destructive",
+      });
+    } finally {
+      setBuyingId(null);
+    }
   };
 
   return (
@@ -322,6 +416,98 @@ const Marketplace = () => {
                   </table>
                 ) : (
                   <p className="text-sm text-muted-foreground py-8 text-center">No market data available yet.</p>
+                )}
+              </CardContent>
+            </Card>
+            <Card className="border-border/60 bg-background/80 shadow-card backdrop-blur-xl">
+              <CardHeader className="flex items-center justify-between">
+                <CardTitle className="flex items-center gap-3 text-lg font-semibold text-muted-foreground">
+                  <Activity className="h-5 w-5 text-primary" />
+                  Live Listings
+                </CardTitle>
+                <Button variant="outline" size="sm" onClick={refreshListings} disabled={loadingListings}>
+                  Refresh
+                </Button>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {loadingListings ? (
+                  <p className="text-sm text-muted-foreground">Loading listings...</p>
+                ) : marketListings.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No NFTs are currently listed for sale.</p>
+                ) : (
+                  <div className="space-y-3">
+                    {marketListings.map((entry) => {
+                      const listing = entry.listing ?? entry;
+                      const listingId = listing.listing_id;
+                      const listingIdText = listingId?.toString?.() ?? String(listingId);
+                      const sellerText = formatPrincipalId(listing.seller);
+                      const floorPrice = formatPrice(unwrapOptional(entry.market?.floor_price));
+                      const totalVolume = formatPrice(entry.market?.total_volume);
+                      const rankingText = formatRanking(entry.market?.ranking);
+                      const listingPrice = formatPrice(listing.unit_price);
+                      const marketOwner = formatPrincipalId(unwrapOptional(entry.market?.current_owner));
+                      const editionSize = unwrapOptional(entry.edition_size);
+                      const isCollection = entry.is_collection;
+                      return (
+                        <div
+                          key={listingIdText}
+                          className="grid gap-4 rounded-2xl border border-border/60 bg-background/70 p-4 sm:grid-cols-[160px_1fr_auto] sm:items-center"
+                        >
+                          <div className="h-40 w-full overflow-hidden rounded-xl bg-muted">
+                            {entry.image_uri ? (
+                              <img src={entry.image_uri} alt={entry.name} className="h-full w-full object-cover" />
+                            ) : (
+                              <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+                                No preview
+                              </div>
+                            )}
+                          </div>
+                          <div className="space-y-3">
+                            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                              <div>
+                                <p className="text-sm font-semibold text-foreground">{entry.name}</p>
+                                <p className="text-xs text-muted-foreground">Listing #{listingIdText}</p>
+                                <p className="text-xs text-muted-foreground">Seller {sellerText}</p>
+                                <p className="text-xs text-muted-foreground">Owner {marketOwner}</p>
+                              </div>
+                              <span className="text-sm font-semibold text-primary">{listingPrice}</span>
+                            </div>
+                            <div className="grid gap-x-4 gap-y-1 text-xs text-muted-foreground sm:grid-cols-2">
+                              <span>Quantity Listed</span>
+                              <span className="text-right text-foreground">{Number(listing.quantity ?? 0)}</span>
+                              <span>Type</span>
+                              <span className="text-right text-foreground">
+                                {isCollection ? "Collection" : "Single"}
+                              </span>
+                              {isCollection && (
+                                <span className="col-span-2 flex items-center justify-between text-foreground">
+                                  <span>Edition Size</span>
+                                  <span>{editionSize ?? "-"}</span>
+                                </span>
+                              )}
+                              <span>Floor Price</span>
+                              <span className="text-right text-foreground">{floorPrice}</span>
+                              <span>Total Volume</span>
+                              <span className="text-right text-foreground">{totalVolume}</span>
+                              <span>Ranking</span>
+                              <span className="text-right text-foreground">{rankingText}</span>
+                            </div>
+                          </div>
+                          <div className="flex flex-col items-end justify-between gap-3">
+                            <Button
+                              onClick={() => handleBuy(entry)}
+                              disabled={buyingId === listingIdText}
+                            >
+                              {buyingId === listingIdText ? "Buying..." : "Buy"}
+                            </Button>
+                            <span className="text-xs text-muted-foreground">
+                              Token {listing.token_id?.toString?.() ?? String(listing.token_id)}
+                            </span>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
                 )}
               </CardContent>
             </Card>

--- a/src/Mementic_frontend/src/Pages/Portfolio.jsx
+++ b/src/Mementic_frontend/src/Pages/Portfolio.jsx
@@ -1,1032 +1,682 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Button } from "../components/ui/Button";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "../components/ui/Card";
-import { Input } from "../components/ui/Input";
-import {
-  TrendingUp,
-  Coins,
-  Crown,
-  ArrowUp,
-  ArrowDown,
-  User,
-  Sparkles,
-  MessageSquare,
-} from "lucide-react";
-import { useAuth } from "../contexts/AuthContext";
-import { useLocation, useNavigate } from "react-router-dom";
-import { useToast } from "../hooks/use-toast";
-import { FeedbackForm } from "../components/FeedbackForm";
+import { useEffect, useState } from "react";
 import Navigation from "../components/Navigation";
-
+import { Button } from "../components/ui/Button";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/Card";
+import { Input } from "../components/ui/Input";
+import { Textarea } from "../components/ui/Textarea";
+import { useAuth } from "../contexts/AuthContext";
+import { useToast } from "../hooks/use-toast";
 import backendService from "../services/backendService";
 
+const TABS = [
+  { key: "generated", label: "Generated" },
+  { key: "winners", label: "Winners" },
+  { key: "minted", label: "My Minted NFTs" },
+];
 
+const emptyMintForm = {
+  open: false,
+  meme: null,
+  mode: "single",
+  name: "",
+  symbol: "MEME",
+  description: "",
+  royaltyBps: "0",
+  externalUrl: "",
+  license: "",
+  attributes: "",
+  editionCount: "10",
+};
 
+const emptyListingForm = {
+  open: false,
+  nft: null,
+  price: "",
+  quantity: "1",
+  expiresHours: "",
+};
 
-/**
- * UI NFT shape (for reference)
- * {
- *   id: string,
- *   title: string,
- *   emoji: string,
- *   votes: number,
- *   earnedIcp: number,
- *   views: number,
- *   status: "earning" | "selling" | "minted" | "unknown",
- *   imageUrl?: string
- * }
- */
+function parseAttributes(attributeText) {
+  if (!attributeText.trim()) return [];
+  return attributeText
+    .split(",")
+    .map((pair) => pair.trim())
+    .filter(Boolean)
+    .map((pair) => {
+      const [key, value] = pair.split(":");
+      return [key?.trim() ?? "trait", value?.trim() ?? "value"];
+    });
+}
 
-const SkeletonStat = () => (
-  <Card>
-    <CardContent className="p-6 text-center animate-pulse">
-      <div className="w-8 h-8 mx-auto mb-2 rounded-full bg-muted" />
-      <div className="h-7 w-24 mx-auto bg-muted rounded mb-2" />
-      <div className="h-4 w-20 mx-auto bg-muted rounded" />
-    </CardContent>
-  </Card>
-);
+function icpToE8s(value) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error("Price is required");
+  }
+  if (!/^\d*(\.\d{0,8})?$/.test(trimmed)) {
+    throw new Error("Enter price in ICP using up to 8 decimals");
+  }
+  const [wholeRaw, fractionRaw = ""] = trimmed.split(".");
+  const whole = wholeRaw.length ? BigInt(wholeRaw) : 0n;
+  const fraction = fractionRaw.padEnd(8, "0").slice(0, 8);
+  return whole * 100000000n + BigInt(fraction);
+}
 
-const SkeletonTile = () => (
-  <Card className="group">
-    <CardHeader>
-      <div className="flex items-center justify-between">
-        <div className="w-16 h-16 rounded bg-muted animate-pulse" />
-        <div className="h-5 w-40 bg-muted rounded animate-pulse" />
-      </div>
-    </CardHeader>
-    <CardContent className="space-y-4">
-      <div className="h-6 w-48 bg-muted rounded animate-pulse" />
-      <div className="space-y-2">
-        <div className="h-4 w-full bg-muted rounded animate-pulse" />
-        <div className="h-4 w-2/3 bg-muted rounded animate-pulse" />
-        <div className="h-4 w-1/2 bg-muted rounded animate-pulse" />
-      </div>
-      <div className="flex gap-2">
-        <div className="h-9 w-full bg-muted rounded animate-pulse" />
-        <div className="h-9 w-full bg-muted rounded animate-pulse" />
-      </div>
-    </CardContent>
-  </Card>
-);
+function buildMetadata(formState, imageUri) {
+  return {
+    name: formState.name.trim(),
+    symbol: formState.symbol.trim() || "MEME",
+    description: formState.description.trim() ? [formState.description.trim()] : [],
+    royalty_bps:
+      formState.royaltyBps && formState.royaltyBps.trim()
+        ? [Number(formState.royaltyBps)]
+        : [],
+    external_url: formState.externalUrl.trim() ? [formState.externalUrl.trim()] : [],
+    attributes: parseAttributes(formState.attributes),
+    license: formState.license.trim() ? [formState.license.trim()] : [],
+    image_uri: imageUri,
+  };
+}
+
+function formatPrincipalId(principal) {
+  if (!principal) return "-";
+  const text = principal?.toText?.() ?? principal?.toString?.() ?? String(principal);
+  if (text.length <= 10) return text;
+  return `${text.slice(0, 5)}...${text.slice(-3)}`;
+}
+
+function formatIcpValue(value) {
+  if (value === undefined || value === null) return "-";
+  try {
+    const nat = typeof value === "bigint" ? value : BigInt(value);
+    const whole = nat / 100000000n;
+    const fraction = nat % 100000000n;
+    const fractionStr = fraction
+      .toString()
+      .padStart(8, "0")
+      .replace(/0+$/, "");
+    return `${whole}${fractionStr ? `.${fractionStr}` : ""} ICP`;
+  } catch (error) {
+    console.warn("Failed to format ICP value", value, error);
+    return "-";
+  }
+}
+
+function formatRanking(rank) {
+  if (!rank && rank !== 0) return "Unranked";
+  const numeric = Number(rank);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return "Unranked";
+  }
+  return `#${numeric}`;
+}
+
+const unwrapOptional = (value) => (Array.isArray(value) ? value[0] : value);
+
+const toDateFromNs = (ns) => {
+  if (ns === undefined || ns === null) return new Date();
+  const big = typeof ns === "bigint" ? ns : BigInt(ns);
+  return new Date(Number(big / 1000000n));
+};
+
+const relativeTimeFromNow = (date) => {
+  const now = Date.now();
+  const diff = Math.max(0, now - date.getTime());
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days} day${days === 1 ? "" : "s"} ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months} month${months === 1 ? "" : "s"} ago`;
+  const years = Math.floor(months / 12);
+  return `${years} year${years === 1 ? "" : "s"} ago`;
+};
 
 const Portfolio = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
+  const { isAuthenticated } = useAuth();
   const { toast } = useToast();
-  const {
-    principal,
-    username,
-    logout,
-    isAuthenticated,
-    isLoading: authLoading,
-    updateUsername,
-  } = useAuth();
-
-  const locationState = location.state ?? {};
-  const requestedFrom = locationState?.from;
-  const requireUsername = Boolean(locationState?.requireUsername);
-
-  const sanitizedUsername = typeof username === "string" ? username.trim() : "";
-  const hasUsername = sanitizedUsername.length > 0;
-
+  const [activeTab, setActiveTab] = useState(TABS[0].key);
   const [loading, setLoading] = useState(true);
-  const [nfts, setNfts] = useState([]);
-  const [error, setError] = useState("");
+  const [generatedMemes, setGeneratedMemes] = useState([]);
+  const [winners, setWinners] = useState([]);
+  const [mintedNfts, setMintedNfts] = useState([]);
+  const [mintForm, setMintForm] = useState(emptyMintForm);
+  const [listingForm, setListingForm] = useState(emptyListingForm);
   const [refreshing, setRefreshing] = useState(false);
 
-  const [usernameInput, setUsernameInput] = useState(sanitizedUsername);
-  const [usernameError, setUsernameError] = useState("");
-  const [usernameSaved, setUsernameSaved] = useState(false);
-  const [savingUsername, setSavingUsername] = useState(false);
-  const [showUsernameEditor, setShowUsernameEditor] = useState(!hasUsername || requireUsername);
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+    const run = async () => {
+      setLoading(true);
+      try {
+        await backendService.ensureReady();
+        const memes = await backendService.getUserMemes();
+        const minted = await backendService.getMyMintedNfts([]);
 
-  const redirectAfterSaveRef = useRef(requestedFrom || null);
+        const mintedIdSet = new Set(minted.map((item) => Number(item.meme_id ?? 0)));
+        const generated = memes.filter((meme) => !mintedIdSet.has(Number(meme.id)));
+        const winnerChecks = await Promise.all(
+          generated.map(async (meme) => ({
+            meme,
+            isWinner: await backendService.isWinner(meme.id),
+          }))
+        );
 
-  const displayName =
-    sanitizedUsername || (principal ? `${principal.slice(0, 8)}...${principal.slice(-6)}` : "Not logged in");
-  const principalPreview = principal
-    ? `${principal.slice(0, 8)}...${principal.slice(-6)}`
-    : "";
+        const eligibleWinners = winnerChecks
+          .filter((entry) => entry.isWinner)
+          .map((entry) => ({
+            meme: entry.meme,
+            alreadyMinted: mintedIdSet.has(Number(entry.meme.id)),
+          }));
 
-  // Calculate portfolio stats
-  const totalVotes = nfts.reduce((sum, nft) => sum + nft.votes, 0);
-  const totalEarnings = nfts.reduce((sum, nft) => sum + nft.earnedIcp, 0);
-  const totalViews = nfts.reduce((sum, nft) => sum + nft.views, 0);
-  const avgEarningsPerVote = totalVotes > 0 ? totalEarnings / totalVotes : 0;
+        if (!cancelled) {
+          setGeneratedMemes(generated);
+          setWinners(eligibleWinners);
+          setMintedNfts(minted);
+        }
+      } catch (error) {
+        console.error("Failed to load portfolio data", error);
+        toast({
+          title: "Portfolio refresh failed",
+          description: error.message ?? String(error),
+          variant: "destructive",
+        });
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+          setRefreshing(false);
+        }
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, toast]);
 
-  const generatedCount = nfts.length;
-  const mintedCount = nfts.filter(nft => nft.isMinted).length;
-  const listedCount = nfts.filter(nft => nft.isListed).length;
-  const totalSales = nfts.reduce((sum, nft) => sum + (nft.totalSales || 0), 0);
+  const openMintForm = (meme) => {
+    setMintForm({
+      ...emptyMintForm,
+      open: true,
+      meme,
+      name: meme.meme_data.caption ?? `Meme #${meme.id}`,
+      description: meme.meme_data.caption ?? "",
+      externalUrl: meme.meme_data.image_url,
+    });
+  };
 
-  const mintedProgress = generatedCount > 0 ? Math.round((mintedCount / generatedCount) * 100) : 0;
-  const listedProgress = generatedCount > 0 ? Math.round((listedCount / generatedCount) * 100) : 0;
+  const openListingForm = (nft) => {
+    setListingForm({
+      ...emptyListingForm,
+      open: true,
+      nft,
+      quantity: nft.is_collection ? String(nft.owned_quantity ?? 1) : "1",
+    });
+  };
 
-  const generatedMemes = nfts.filter(nft => !nft.isMinted);
-  const mintedNFTs = nfts.filter(nft => nft.isMinted);
+  const closeMintForm = () => setMintForm(emptyMintForm);
+  const closeListingForm = () => setListingForm(emptyListingForm);
 
-  const handleSell = async (id) => {
+  const refreshData = async () => {
+    setRefreshing(true);
+    setLoading(true);
+    setMintForm(emptyMintForm);
+    setListingForm(emptyListingForm);
+    // Trigger effect by updating state via ensureReady
+    if (isAuthenticated) {
+      try {
+        const memes = await backendService.getUserMemes();
+        const minted = await backendService.getMyMintedNfts([]);
+        const mintedIdSet = new Set(minted.map((item) => Number(item.meme_id ?? 0)));
+        const generated = memes.filter((meme) => !mintedIdSet.has(Number(meme.id)));
+        const winnerChecks = await Promise.all(
+          generated.map(async (meme) => ({
+            meme,
+            isWinner: await backendService.isWinner(meme.id),
+          }))
+        );
+        const eligibleWinners = winnerChecks
+          .filter((entry) => entry.isWinner)
+          .map((entry) => ({
+            meme: entry.meme,
+            alreadyMinted: mintedIdSet.has(Number(entry.meme.id)),
+          }));
+        setGeneratedMemes(generated);
+        setWinners(eligibleWinners);
+        setMintedNfts(minted);
+      } catch (error) {
+        console.error("Failed to refresh portfolio", error);
+        toast({
+          title: "Refresh failed",
+          description: error.message ?? String(error),
+          variant: "destructive",
+        });
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    }
+  };
+
+  const handleMintSubmit = async (event) => {
+    event.preventDefault();
+    if (!mintForm.meme) return;
     try {
-      // List for 1 ICP (100000000 e8s)
-      const priceE8s = BigInt(100000000);
-      await backendService.listMemeForSale(BigInt(id), priceE8s);
+      const metadata = buildMetadata(mintForm, mintForm.meme.meme_data.image_url);
+      if (!metadata.name) {
+        throw new Error("Name is required");
+      }
+      if (metadata.royalty_bps.length && (metadata.royalty_bps[0] < 0 || metadata.royalty_bps[0] > 1000)) {
+        throw new Error("Royalty must be between 0 and 1000 basis points");
+      }
+      if (mintForm.mode === "collection") {
+        const editionCount = Number(mintForm.editionCount);
+        if (!Number.isInteger(editionCount) || editionCount < 2) {
+          throw new Error("Collection mint requires at least 2 editions");
+        }
+        await backendService.mintCollectionNft(mintForm.meme.id, editionCount, metadata);
+      } else {
+        await backendService.mintSingleNft(mintForm.meme.id, metadata);
+      }
       toast({
-        title: "Meme listed for sale",
-        description: "Your meme is now available on the marketplace for 1 ICP.",
+        title: "Mint successful",
+        description: "Your NFT is ready in My Minted NFTs.",
       });
-      // Refresh the portfolio to show updated status
-      await fetchData();
+      await refreshData();
     } catch (error) {
-      console.error('Failed to list meme for sale:', error);
+      console.error("Mint failed", error);
       toast({
-        title: "Listing failed",
-        description: "Could not list your meme for sale. Please try again.",
+        title: "Mint failed",
+        description: error.message ?? String(error),
         variant: "destructive",
       });
     }
   };
 
-  const handleKeep = (id) => {
-    toast({
-      title: "Meme kept",
-      description: "Your meme will continue earning votes and may be minted as an NFT.",
-    });
-  };
-
-  const handleLogout = async () => {
-    await logout();
-    navigate('/');
-  };
-
-  // Redirect if not authenticated
-  useEffect(() => {
-    if (!authLoading && !isAuthenticated) {
-      navigate("/login");
-    }
-  }, [isAuthenticated, authLoading, navigate]);
-
-  useEffect(() => {
-    setUsernameInput(sanitizedUsername);
-    if (sanitizedUsername) {
-      setShowUsernameEditor(false);
-    }
-  }, [sanitizedUsername]);
-
-  useEffect(() => {
-    if (requestedFrom) {
-      redirectAfterSaveRef.current = requestedFrom;
-    }
-  }, [requestedFrom]);
-
-  useEffect(() => {
-    if (!requireUsername) return;
-
-    setShowUsernameEditor(true);
-    if (requestedFrom) {
-      redirectAfterSaveRef.current = requestedFrom;
-    }
-
-    navigate(location.pathname, {
-      replace: true,
-      state: requestedFrom ? { from: requestedFrom } : undefined,
-    });
-  }, [requireUsername, requestedFrom, location.pathname, navigate]);
-
-  const handleEditUsername = () => {
-    setShowUsernameEditor(true);
-    setUsernameSaved(false);
-    setUsernameError("");
-    setUsernameInput(sanitizedUsername);
-  };
-
-  const handleCancelUsername = () => {
-    setShowUsernameEditor(false);
-    setUsernameError("");
-    setUsernameInput(sanitizedUsername);
-  };
-
-  const handleUsernameSubmit = async (event) => {
+  const handleListingSubmit = async (event) => {
     event.preventDefault();
-    const trimmed = typeof usernameInput === "string" ? usernameInput.trim() : "";
-
-    if (trimmed.length < 3) {
-      setUsernameError("Username must be at least 3 characters long.");
-      return;
-    }
-
-    if (trimmed.length > 32) {
-      setUsernameError("Username must be 32 characters or fewer.");
-      return;
-    }
-
+    if (!listingForm.nft) return;
     try {
-      setSavingUsername(true);
-      await updateUsername(trimmed);
-      setUsernameSaved(true);
-      setShowUsernameEditor(false);
-      setUsernameError("");
+      const price = icpToE8s(listingForm.price);
+      const quantity = Math.max(1, Number(listingForm.quantity));
+      const expiresAt = listingForm.expiresHours.trim()
+        ? (() => {
+            const hours = Number(listingForm.expiresHours);
+            const clamped = Number.isFinite(hours) && hours > 0 ? hours : 0;
+            const nowNs = BigInt(Date.now()) * 1000000n;
+            const durationNs = BigInt(Math.floor(clamped)) * 60n * 60n * 1000000000n;
+            return [nowNs + durationNs];
+          })()
+        : [];
+      await backendService.listForSale(
+        listingForm.nft.token_id,
+        price,
+        quantity,
+        expiresAt
+      );
       toast({
-        title: "Profile updated",
-        description: "Your username is live across the marketplace and creator studio.",
+        title: "Listing created",
+        description: "Your NFT is live on the marketplace.",
       });
-
-      const target = redirectAfterSaveRef.current;
-      if (target) {
-        redirectAfterSaveRef.current = null;
-        setTimeout(() => {
-          navigate(target, { replace: true });
-        }, 400);
-      }
+      await refreshData();
     } catch (error) {
-      console.error("Failed to update username:", error);
-      setUsernameError("Failed to save username. Please try again.");
-    } finally {
-      setSavingUsername(false);
+      console.error("Listing failed", error);
+      toast({
+        title: "Listing failed",
+        description: error.message ?? String(error),
+        variant: "destructive",
+      });
     }
   };
 
-  // Safely unwrap candid optionals that arrive as [] | [value]
-  function unopt(v) {
-    return Array.isArray(v) ? v[0] : v;
-  }
-
-  /**
-   * Safely convert BigInt to number, handling large values
-   */
-  function safeBigIntToNumber(value) {
-    if (typeof value === 'bigint') {
-      // Check if BigInt is within safe number range
-      if (value > Number.MAX_SAFE_INTEGER) {
-        return Number.MAX_SAFE_INTEGER;
-      }
-      if (value < Number.MIN_SAFE_INTEGER) {
-        return Number.MIN_SAFE_INTEGER;
-      }
-      return Number(value);
-    }
-    return Number(value) || 0;
-  }
-
-  // Map canister records -> UI
-  const mapToUi = (item) => {
-    const memeData = unopt(item?.meme_data) || {};
-    const marketData = item?.sale_metadata ?? item?.market_data ?? {};
-    const votes = safeBigIntToNumber(item?.votes?.upvotes ?? item?.votes ?? 0);
-
-    // Handle bigint conversion for earned ICP (from market data)
-    let earnedIcp = 0;
-    if (marketData?.total_earned) {
-      earnedIcp = safeBigIntToNumber(marketData.total_earned) / 100000000; // Convert e8s to ICP
-    }
-
-    // Determine status based on market data
-    let status = "earning";
-    if (marketData?.is_listed) {
-      status = "selling";
-    }
-
-    return {
-      id: String(item?.meme_id ?? item?.id ?? crypto.randomUUID()),
-      title: memeData?.prompt || item?.title || "Untitled Meme",
-      emoji: "🖼️",
-      votes: votes,
-      earnedIcp: Number.isFinite(earnedIcp) ? earnedIcp : 0,
-      views: safeBigIntToNumber(item?.views || marketData?.views || 0),
-      status,
-      imageUrl: memeData?.image_url,
-      // Market data
-      isListed: marketData?.is_listed || false,
-      listingPrice: marketData?.listing_price ? safeBigIntToNumber(marketData.listing_price) / 100000000 : null,
-      totalSales: safeBigIntToNumber(marketData?.total_sales || 0),
-      lastSalePrice: marketData?.last_sale_price ? safeBigIntToNumber(marketData.last_sale_price) / 100000000 : null,
-      listedAt: marketData?.listed_at,
-      lastSaleAt: marketData?.last_sale_at,
-      // isMinted will be set in fetchData after checking with backend
-      isMinted: false, // default value, will be overridden
-    };
-  };
-
-  async function fetchData() {
-    if (!isAuthenticated) return;
-    setLoading(true);
-    setError("");
-    try {
-      // Ensure backend service is ready
-      await backendService.ensureReady();
-
-      // Use centralized backend service
-      let mine = [];
-      try {
-        mine = await backendService.getUserMemes();
-        console.log(`Fetched ${mine?.length || 0} user memes`);
-      } catch (error) {
-        console.warn("Failed to fetch user memes:", error);
-        // Create sample data for testing
-        mine = [
-          {
-            id: "sample-1",
-            meme_data: {
-              prompt: "Sample meme for testing",
-              image_url: "",
-              image_filename: "sample.png",
-              image_format: "png",
-              metadata: {
-                processing_time: 1.5,
-                timestamp: Date.now() * 1000000,
-                file_size_bytes: 1024000,
-                service: "sample"
-              }
-            },
-            created_at: Date.now(),
-            sale_metadata: {
-              is_listed: false,
-              listing_price: null,
-              listed_at: null,
-              total_sales: 0,
-              total_earned: 0,
-              last_sale_price: null,
-              last_sale_at: null
-            },
-            views: 0
-          }
-        ];
-        console.log("Using sample data due to backend issues");
-      }
-
-      if (!mine || !Array.isArray(mine)) {
-        console.warn("Invalid response from getUserMemes:", mine);
-        setNfts([]);
-        return;
-      }
-
-      // Check minting status for each meme
-      const ui = await Promise.all(mine.map(async (item, index) => {
-        const baseUi = mapToUi(item);
-        try {
-          // Add a small delay to avoid overwhelming the backend
-          if (index > 0) {
-            await new Promise(resolve => setTimeout(resolve, 100));
-          }
-          const isMinted = await backendService.isMemeMinted(BigInt(baseUi.id));
-          return { ...baseUi, isMinted: Boolean(isMinted) };
-        } catch (error) {
-          console.warn(`Failed to check minting status for meme ${baseUi.id}:`, error);
-          return { ...baseUi, isMinted: false };
-        }
-      }));
-
-      setNfts(ui);
-    } catch (e) {
-      console.error("Error loading portfolio:", e);
-      // Check if it's an authentication/storage error
-      if (e.message && (e.message.includes('anchor_number') || e.message.includes('storage'))) {
-        setError("Authentication issue. Please try logging out and back in.");
-      } else {
-        setError("Failed to load your portfolio. Please try again.");
-      }
-      setNfts([]);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  useEffect(() => {
-    if (isAuthenticated) {
-      fetchData();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAuthenticated]);
-
-  // Periodic refresh of vote counts and stats
-  useEffect(() => {
-    if (!isAuthenticated || loading) return;
-
-    const refreshPortfolio = async () => {
-      if (refreshing) return; // Prevent multiple simultaneous refreshes
-
-      setRefreshing(true);
-      try {
-        // Refresh vote counts for existing memes
-        if (nfts.length > 0) {
-          const updatedNfts = await Promise.all(
-            nfts.map(async (nft) => {
-              try {
-                const memeIdBigInt = BigInt(nft.id);
-                const voteData = await backendService.getMemeVotes(memeIdBigInt);
-
-                if (voteData) {
-                  const newVotes = safeBigIntToNumber(voteData.upvotes) - safeBigIntToNumber(voteData.downvotes);
-                  return { ...nft, votes: newVotes };
-                }
-                return nft;
-              } catch (error) {
-                console.warn(`Failed to refresh votes for meme ${nft.id}:`, error);
-                return nft;
-              }
-            })
-          );
-          setNfts(updatedNfts);
-        }
-      } catch (error) {
-        console.warn("Failed to refresh portfolio data:", error);
-      } finally {
-        setRefreshing(false);
-      }
-    };
-
-    // Initial refresh after loading
-    const initialRefreshTimer = setTimeout(refreshPortfolio, 2000);
-
-    // Set up periodic refresh every 30 seconds
-    const refreshInterval = setInterval(refreshPortfolio, 30000);
-
-    return () => {
-      clearTimeout(initialRefreshTimer);
-      clearInterval(refreshInterval);
-    };
-  }, [isAuthenticated, loading, nfts]);
-
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 text-foreground">
-      <Navigation />
-      <main className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 pb-16 pt-10">
-        <Card className="border-primary/20 bg-gradient-to-br from-primary/10 via-primary/5 to-secondary/10 text-foreground shadow-lg shadow-primary/10">
-          <CardContent className="p-8">
-            <div className="flex flex-col gap-8">
-              {/* Header Section */}
-              <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
-                <div className="space-y-2">
-                  <p className="text-xs font-medium uppercase tracking-[0.3em] text-primary/70 pt-3">Creator Profile</p>
-                  <h1 className="text-3xl font-semibold md:text-4xl">
-                    {displayName || "Anonymous"}
-                  </h1>
-                  <p className="max-w-md text-sm text-foreground/80">
-                    Track your meme creations, earnings, and momentum across the Mementic universe.
-                  </p>
-                </div>
-              </div>
-
-              {/* Stats Grid */}
-              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-                <div className="rounded-2xl border border-primary/30 bg-primary/10 p-4 text-center">
-                  <div className="flex items-center justify-center mb-2">
-                    <Sparkles className="h-5 w-5 text-primary" />
-                  </div>
-                  <p className="text-xs uppercase tracking-wide text-primary/70">Voting Power</p>
-                  <p className="mt-2 text-2xl font-semibold text-primary">{totalVotes.toLocaleString()}</p>
-                  <p className="text-xs text-primary/60 mt-1">Total upvotes</p>
-                </div>
-
-                <div className="rounded-2xl border border-secondary/30 bg-secondary/10 p-4 text-center">
-                  <div className="flex items-center justify-center mb-2">
-                    <Crown className="h-5 w-5 text-secondary" />
-                  </div>
-                  <p className="text-xs uppercase tracking-wide text-secondary/70">Memes Created</p>
-                  <p className="mt-2 text-2xl font-semibold text-secondary">{generatedCount.toLocaleString()}</p>
-                  <p className="text-xs text-secondary/60 mt-1">Total generated</p>
-                </div>
-
-                <div className="rounded-2xl border border-accent/30 bg-accent/10 p-4 text-center">
-                  <div className="flex items-center justify-center mb-2">
-                    <TrendingUp className="h-5 w-5 text-accent" />
-                  </div>
-                  <p className="text-xs uppercase tracking-wide text-accent/70">Minted NFTs</p>
-                  <p className="mt-2 text-2xl font-semibold text-accent">{mintedCount.toLocaleString()}</p>
-                  <p className="text-xs text-accent/60 mt-1">On-chain assets</p>
-                </div>
-
-                <div className="rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 text-center">
-                  <div className="flex items-center justify-center mb-2">
-                    <Coins className="h-5 w-5 text-amber-600" />
-                  </div>
-                  <p className="text-xs uppercase tracking-wide text-amber-600/70">Total Sales</p>
-                  <p className="mt-2 text-2xl font-semibold text-amber-600">{totalSales.toLocaleString()}</p>
-                  <p className="text-xs text-amber-600/60 mt-1">Marketplace transactions</p>
-                </div>
-              </div>
-
-              {/* Principal Info */}
-              <div className="rounded-2xl border border-primary/30 bg-primary/5 p-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <span className="text-xs uppercase tracking-wide text-primary/70">Principal ID</span>
-                    <span className="mt-2 block text-sm font-mono text-foreground" title={principal}>
-                      {principal ? principalPreview : "Not connected"}
-                    </span>
-                  </div>
-                  <div className="text-right">
-                    <p className="text-xs text-primary/70">Marketplace Listings</p>
-                    <p className="text-lg font-semibold text-primary">{listedCount.toLocaleString()}</p>
-                  </div>
-                </div>
-              </div>
-
-              {/* Username Editor */}
-              {usernameSaved && !showUsernameEditor && (
-                <div className="rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-sm text-emerald-700 dark:text-emerald-200">
-                  Username updated successfully.
-                </div>
+  const renderGenerated = () => (
+    <div className="grid gap-4">
+      {generatedMemes.length === 0 && (
+        <Card className="border-dashed border-border/60 bg-background/70">
+          <CardContent className="p-8 text-center text-muted-foreground">
+            You have no generated memes waiting to be minted.
+          </CardContent>
+        </Card>
+      )}
+      {generatedMemes.map((meme) => (
+        <Card key={meme.id} className="border-border/60 bg-background/80 shadow-card">
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold">#{meme.id}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">{meme.meme_data.prompt}</p>
+              {meme.meme_data.caption && (
+                <p className="text-sm font-medium text-foreground">{meme.meme_data.caption}</p>
               )}
-
-              {showUsernameEditor ? (
-                <form onSubmit={handleUsernameSubmit} className="space-y-3">
-                  <div className="flex items-center gap-2 text-sm text-foreground/80">
-                    <User className="h-4 w-4 text-primary" />
-                    <span>Choose how you appear to other creators</span>
-                  </div>
-                  <Input
-                    value={usernameInput}
-                    onChange={(event) => {
-                      setUsernameInput(event.target.value);
-                      setUsernameError("");
-                      setUsernameSaved(false);
-                    }}
-                    placeholder="e.g. MemeMaestro"
-                    maxLength={32}
-                    disabled={savingUsername}
-                    className="bg-background text-foreground placeholder:text-muted-foreground"
-                  />
-                  {usernameError && <p className="text-xs text-destructive">{usernameError}</p>}
-                  <div className="flex flex-col gap-2 sm:flex-row">
-                    <Button type="submit" disabled={savingUsername} className="sm:flex-1">
-                      {savingUsername ? "Saving…" : "Save username"}
-                    </Button>
-                    {hasUsername && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        className="sm:flex-1"
-                        onClick={handleCancelUsername}
-                        disabled={savingUsername}
-                      >
-                        Cancel
-                      </Button>
-                    )}
-                  </div>
-                </form>
-              ) : (
-                <div className="flex flex-col gap-3 text-sm sm:flex-row sm:items-center sm:justify-between">
-                  <p className="text-foreground/80">
-                    {hasUsername
-                      ? "Your username is visible everywhere instead of your principal."
-                      : "Pick a username so your principal stays private."}
-                  </p>
-                  <div className="flex items-center gap-3">
-                    {!hasUsername && (
-                      <Button size="sm" variant="secondary" onClick={handleEditUsername}>
-                        Add username
-                      </Button>
-                    )}
-                    {hasUsername && (
-                      <Button size="sm" variant="ghost" onClick={handleEditUsername}>
-                        Edit username
-                      </Button>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* Action Buttons */}
-              <div className="flex flex-wrap gap-3">
-                <Button
-                  variant="secondary"
-                  onClick={() => navigate("/myplace")}
-                  className="bg-primary hover:bg-primary"
-                >
-                  <Sparkles className="mr-2 h-4 w-4" />
-                  Create meme
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => navigate("/marketplace")}
-                  className="border-primary/40 text-foreground hover:bg-primary"
-                >
-                  Browse marketplace
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={async () => {
-                    setRefreshing(true);
-                    try {
-                      await fetchData();
-                      toast({
-                        title: "Portfolio refreshed",
-                        description: "Your latest stats are now up to date.",
-                      });
-                    } catch (error) {
-                      toast({
-                        title: "Refresh failed",
-                        description: "Could not refresh portfolio data.",
-                        variant: "destructive",
-                      });
-                    } finally {
-                      setRefreshing(false);
-                    }
-                  }}
-                  disabled={refreshing || loading}
-                  className="border-primary/40 text-foreground hover:bg-primary/10"
-                >
-                  {refreshing ? (
-                    <div className="mr-2 h-4 w-4 animate-spin rounded-full border border-current border-t-transparent" />
-                  ) : (
-                    <ArrowUp className="mr-2 h-4 w-4" />
-                  )}
-                  Refresh
-                </Button>
-                <Button
-                  variant="ghost"
-                  onClick={handleLogout}
-                  className="text-rose-800 hover:bg-rose-500"
-                >
-                  <ArrowDown className="mr-2 h-4 w-4" />
-                  Logout
-                </Button>
-              </div>
+            </div>
+            <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+              <span>Created {relativeTimeFromNow(toDateFromNs(meme.created_at))}</span>
             </div>
           </CardContent>
         </Card>
+      ))}
+    </div>
+  );
 
-        <div className="grid gap-6 lg:grid-cols-2">
-          {/* Performance Overview */}
-          <Card className="border-primary/20 bg-gradient-to-br from-card/80 to-card/60 text-card-foreground shadow-lg shadow-primary/10">
-            <CardHeader className="pb-4">
-              <CardTitle className="text-xl font-semibold text-card-foreground flex items-center gap-2">
-                <TrendingUp className="h-5 w-5 text-primary" />
-                Performance Overview
-              </CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Visual breakdown of your portfolio metrics
-              </p>
+  const renderWinners = () => (
+    <div className="grid gap-4">
+      {winners.length === 0 && (
+        <Card className="border-dashed border-border/60 bg-background/70">
+          <CardContent className="p-8 text-center text-muted-foreground">
+            No winning memes waiting for minting yet. Keep competing!
+          </CardContent>
+        </Card>
+      )}
+      {winners.map(({ meme, alreadyMinted }) => (
+        <Card key={meme.id} className="border-border/60 bg-background/80 shadow-card">
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle className="text-lg font-semibold">Weekly Winner #{meme.id}</CardTitle>
+            <Button
+              disabled={alreadyMinted}
+              onClick={() => openMintForm(meme)}
+            >
+              {alreadyMinted ? "Already Minted" : "Convert to NFT"}
+            </Button>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-[240px_1fr]">
+            <img
+              src={meme.meme_data.image_url}
+              alt={meme.meme_data.caption ?? `Meme ${meme.id}`}
+              className="h-48 w-full rounded-xl object-cover"
+            />
+            <div className="space-y-3">
+              <p className="text-sm text-muted-foreground">{meme.meme_data.prompt}</p>
+              {meme.meme_data.caption && (
+                <p className="text-sm font-medium text-foreground">{meme.meme_data.caption}</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+
+  const renderMinted = () => (
+    <div className="grid gap-4 md:grid-cols-2">
+      {mintedNfts.length === 0 && (
+        <Card className="border-dashed border-border/60 bg-background/70 md:col-span-2">
+          <CardContent className="p-8 text-center text-muted-foreground">
+            Mint a winning meme to see it here.
+          </CardContent>
+        </Card>
+      )}
+      {mintedNfts.map((nft) => {
+        const ownedQuantity = Number(nft.owned_quantity ?? 0);
+        const marketInfo = nft.market ?? {};
+        const listingPrice = unwrapOptional(marketInfo.listing_price);
+        const floorPrice = unwrapOptional(marketInfo.floor_price);
+        const lastSalePrice = unwrapOptional(marketInfo.last_sale_price);
+        const lastSaleAt = unwrapOptional(marketInfo.last_sale_at);
+        const ranking = unwrapOptional(marketInfo.ranking);
+        const hasActiveListing = Boolean(
+          marketInfo.listed && Number(marketInfo.listed_quantity ?? 0) > 0
+        );
+        const totalSalesText = marketInfo.total_sales?.toString?.() ?? String(marketInfo.total_sales ?? 0);
+
+        return (
+          <Card key={nft.token_id.toString()} className="border-border/60 bg-background/80 shadow-card">
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold">{nft.name}</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-6">
-              {/* Custom Bar Chart */}
-              <div className="space-y-4">
-                <div className="h-64 w-full">
-                  <svg viewBox="0 0 400 200" className="w-full h-full">
-                    {/* Grid lines */}
-                    <defs>
-                      <pattern id="grid" width="40" height="20" patternUnits="userSpaceOnUse">
-                        <path d="M 40 0 L 0 0 0 20" fill="none" stroke="currentColor" strokeWidth="0.5" opacity="0.1"/>
-                      </pattern>
-                    </defs>
-                    <rect width="100%" height="100%" fill="url(#grid)" />
-
-                    {/* Bars */}
-                    {[
-                      { label: 'ICP Earned', value: totalEarnings, max: Math.max(totalEarnings * 1.5, 10), color: 'hsl(var(--primary))', icon: Coins },
-                      { label: 'Total Views', value: totalViews, max: Math.max(totalViews * 1.5, 1000), color: 'hsl(var(--secondary))', icon: Sparkles },
-                      { label: 'Avg ICP/Vote', value: avgEarningsPerVote, max: Math.max(avgEarningsPerVote * 1.5, 1), color: 'hsl(var(--accent))', icon: TrendingUp },
-                      { label: 'Listed %', value: listedProgress, max: 100, color: 'hsl(45 86% 58%)', icon: ArrowUp }
-                    ].map((metric, index) => {
-                      const barHeight = (metric.value / metric.max) * 120;
-                      const x = 60 + index * 80;
-                      const y = 160 - barHeight;
-
-                      return (
-                        <g key={metric.label}>
-                          {/* Bar */}
-                          <rect
-                            x={x}
-                            y={y}
-                            width="40"
-                            height={barHeight}
-                            fill={metric.color}
-                            rx="4"
-                            className="transition-all duration-500 hover:opacity-80"
-                          />
-
-                          {/* Value label on top of bar */}
-                          <text
-                            x={x + 20}
-                            y={y - 8}
-                            textAnchor="middle"
-                            className="text-xs font-semibold fill-current"
-                          >
-                            {metric.label === 'ICP Earned' ? `${metric.value.toFixed(1)}` :
-                             metric.label === 'Total Views' ? `${(metric.value / 1000).toFixed(0)}K` :
-                             metric.label === 'Avg ICP/Vote' ? `${(metric.value / 1000).toFixed(2)}` :
-                             `${metric.value}%`}
-                          </text>
-
-                          {/* X-axis label */}
-                          <text
-                            x={x + 20}
-                            y={180}
-                            textAnchor="middle"
-                            className="text-xs fill-muted-foreground"
-                          >
-                            {metric.label.split(' ')[0]}
-                          </text>
-                        </g>
-                      );
-                    })}
-                  </svg>
-                </div>
-
-                {/* Legend */}
-                <div className="flex flex-wrap justify-center gap-4 text-xs">
-                  {[
-                    { label: 'ICP Earned', color: 'bg-primary', icon: Coins },
-                    { label: 'Total Views', color: 'bg-secondary', icon: Sparkles },
-                    { label: 'Avg ICP/Vote', color: 'bg-accent', icon: TrendingUp },
-                    { label: 'Listed Share', color: 'bg-amber-500', icon: ArrowUp }
-                  ].map((item) => (
-                    <div key={item.label} className="flex items-center gap-1">
-                      <div className={`w-3 h-3 rounded ${item.color}`} />
-                      <span className="text-muted-foreground">{item.label}</span>
-                    </div>
-                  ))}
+            <CardContent className="space-y-4">
+              <img
+                src={nft.image_uri}
+                alt={nft.name}
+                className="h-48 w-full rounded-xl object-cover"
+              />
+              <div className="space-y-1 text-sm text-muted-foreground">
+                <p>Token ID: {nft.token_id.toString()}</p>
+                <p>Meme ID: {nft.meme_id?.toString?.() ?? "-"}</p>
+                {nft.is_collection && <p>Edition Size: {nft.edition_size ?? "?"}</p>}
+                <p>Owned Quantity: {ownedQuantity}</p>
+                <p>Current Owner: {formatPrincipalId(unwrapOptional(marketInfo.current_owner))}</p>
+                <p>Ranking: {formatRanking(ranking)}</p>
+              </div>
+                <div className="space-y-2 rounded-xl border border-border/60 bg-background/60 p-4 text-xs text-muted-foreground">
+                  <div className="flex items-center justify-between text-sm font-medium text-foreground">
+                    <span>{hasActiveListing ? "Active Listing" : "Not Listed"}</span>
+                    {hasActiveListing && (
+                      <span className="text-primary">{formatIcpValue(listingPrice)}</span>
+                    )}
+                  </div>
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+                    <span>Listed Quantity</span>
+                    <span className="text-right text-foreground">{marketInfo.listed_quantity ?? 0}</span>
+                    <span>Floor Price</span>
+                    <span className="text-right text-foreground">{formatIcpValue(floorPrice)}</span>
+                    <span>Total Volume</span>
+                    <span className="text-right text-foreground">{formatIcpValue(marketInfo.total_volume)}</span>
+                    <span>Last Sale</span>
+                  <span className="text-right text-foreground">
+                    {formatIcpValue(lastSalePrice)}
+                    {lastSaleAt
+                      ? ` · ${relativeTimeFromNow(toDateFromNs(lastSaleAt))}`
+                      : ""}
+                  </span>
+                  <span>Total Sales</span>
+                  <span className="text-right text-foreground">{totalSalesText}</span>
                 </div>
               </div>
+              <Button
+                variant={hasActiveListing ? "default" : "outline"}
+                disabled={ownedQuantity === 0}
+                onClick={() => openListingForm(nft)}
+              >
+                {hasActiveListing ? "Manage Listing" : "List for Sale"}
+              </Button>
             </CardContent>
           </Card>
+        );
+      })}
+    </div>
+  );
 
-          {/* Portfolio Progress */}
-          <Card className="border-secondary/20 bg-gradient-to-br from-card/80 to-card/60 text-card-foreground shadow-lg shadow-secondary/10">
-            <CardHeader className="pb-4">
-              <CardTitle className="text-xl font-semibold text-card-foreground flex items-center gap-2">
-                <Crown className="h-5 w-5 text-secondary" />
-                Portfolio Progress
-              </CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Track your journey from creation to NFT
-              </p>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              {/* Minting Progress */}
-              <div className="space-y-3">
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-card-foreground">NFT Minting Progress</span>
-                  <span className="text-sm text-secondary font-semibold">{mintedProgress}%</span>
-                </div>
-                <div className="w-full bg-muted rounded-full h-2">
-                  <div
-                    className="bg-gradient-to-r from-secondary to-accent h-2 rounded-full transition-all duration-500"
-                    style={{ width: `${mintedProgress}%` }}
-                  />
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  {mintedCount} of {generatedCount} memes minted as NFTs
-                </p>
-              </div>
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Navigation />
+      <main className="mx-auto max-w-6xl px-4 py-12 sm:px-6">
+        <header className="mb-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold">Portfolio</h1>
+            <p className="text-muted-foreground">
+              Manage your generated memes, winners, and minted NFTs.
+            </p>
+          </div>
+          <Button variant="outline" onClick={refreshData} disabled={refreshing || loading}>
+            {refreshing ? "Refreshing..." : "Refresh"}
+          </Button>
+        </header>
 
-              {/* Marketplace Progress */}
-              <div className="space-y-3">
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-card-foreground">Marketplace Activity</span>
-                  <span className="text-sm text-primary font-semibold">{listedCount} listed</span>
-                </div>
-                <div className="w-full bg-muted rounded-full h-2">
-                  <div
-                    className="bg-gradient-to-r from-primary to-accent h-2 rounded-full transition-all duration-500"
-                    style={{ width: `${listedProgress}%` }}
-                  />
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  {listedCount > 0 ? `${listedCount} memes currently listed for sale` : "No memes currently listed for sale"}
-                </p>
-              </div>
-
-              {/* Quick Stats */}
-              <div className="grid grid-cols-2 gap-4 pt-2">
-                <div className="text-center p-3 rounded-lg bg-muted/50">
-                  <p className="text-2xl font-bold text-primary">{generatedCount.toLocaleString()}</p>
-                  <p className="text-xs text-muted-foreground">Created</p>
-                </div>
-                <div className="text-center p-3 rounded-lg bg-muted/50">
-                  <p className="text-2xl font-bold text-secondary">{mintedCount.toLocaleString()}</p>
-                  <p className="text-xs text-muted-foreground">Minted</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+        <div className="mb-8 flex flex-wrap gap-2">
+          {TABS.map((tab) => (
+            <Button
+              key={tab.key}
+              variant={tab.key === activeTab ? "default" : "outline"}
+              onClick={() => setActiveTab(tab.key)}
+            >
+              {tab.label}
+            </Button>
+          ))}
         </div>
 
-        <section className="space-y-10">
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <div className="flex items-center gap-4">
-              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/20 text-primary-foreground">
-                <Sparkles className="h-6 w-6" />
-              </div>
-              <div>
-                <h2 className="text-2xl font-semibold text-foreground">Generated Memes</h2>
-                <p className="text-sm text-foreground/80">
-                  Keep your meme factory buzzing and convert momentum into NFTs.
-                </p>
-              </div>
-            </div>
-            <Button onClick={() => navigate("/myplace")} className="bg-gradient-to-r from-primary to-secondary text-primary-foreground shadow-lg shadow-primary/20">
-              <Sparkles className="mr-2 h-4 w-4" />
-              Create new meme
-            </Button>
+        {loading ? (
+          <Card className="border-border/60 bg-background/70">
+            <CardContent className="p-12 text-center text-muted-foreground">
+              Loading your portfolio...
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-8">
+            {activeTab === "generated" && renderGenerated()}
+            {activeTab === "winners" && renderWinners()}
+            {activeTab === "minted" && renderMinted()}
           </div>
+        )}
 
-          {loading ? (
-            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {Array.from({ length: 6 }).map((_, i) => (
-                <SkeletonTile key={i} />
-              ))}
-            </div>
-          ) : generatedMemes.length === 0 ? (
-            <Card className="border border-dashed border-primary/40 bg-muted/40 py-16 text-center text-foreground">
-              <CardContent>
-                <CardTitle className="text-xl">No generated memes yet</CardTitle>
-                <p className="mt-3 text-sm text-foreground/80">
-                  Launch your first meme to start earning votes and collector attention.
-                </p>
-                <Button onClick={() => navigate("/myplace")} className="mt-6 bg-primary text-primary-foreground">
-                  Start creating
+        {mintForm.open && (
+          <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 px-4">
+            <Card className="w-full max-w-2xl border-border/60 bg-background">
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>Mint NFT</CardTitle>
+                <Button variant="ghost" onClick={closeMintForm}>
+                  Close
                 </Button>
-              </CardContent>
-            </Card>
-          ) : (
-            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {generatedMemes.map((nft) => (
-                <Card key={nft.id} className="border border-primary/20 bg-card shadow-lg shadow-primary/10">
-                  <CardHeader>
-                    <div className="flex items-start justify-between gap-4">
-                      {nft.imageUrl ? (
-                        <img
-                          src={nft.imageUrl}
-                          alt={nft.title}
-                          className="h-16 w-16 rounded-xl object-cover"
-                        />
-                      ) : (
-                        <div className="flex h-16 w-16 items-center justify-center rounded-xl bg-primary/20 text-3xl">
-                          {nft.emoji}
-                        </div>
-                      )}
-                      <div className="flex-1 space-y-1">
-                        <h3 className="text-lg font-semibold text-card-foreground line-clamp-2">{nft.title}</h3>
-                        <p className="text-xs uppercase tracking-wide text-primary/70">#{nft.id}</p>
-                      </div>
-                    </div>
-                  </CardHeader>
-                  <CardContent className="space-y-4 text-sm text-foreground/80">
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      <div className="rounded-xl bg-white/5 p-3">
-                        <p className="text-xs uppercase tracking-wide text-indigo-200/70">Votes</p>
-                        <p className="mt-2 text-xl font-semibold text-amber-100">{nft.votes.toLocaleString()}</p>
-                      </div>
-                      <div className="rounded-xl bg-white/5 p-3">
-                        <p className="text-xs uppercase tracking-wide text-indigo-200/70">Views</p>
-                        <p className="mt-2 text-xl font-semibold text-sky-100">{nft.views.toLocaleString()}</p>
-                      </div>
-                      <div className="rounded-xl bg-white/5 p-3">
-                        <p className="text-xs uppercase tracking-wide text-indigo-200/70">Earned</p>
-                        <p className="mt-2 text-xl font-semibold text-emerald-100">{nft.earnedIcp.toFixed(4)} ICP</p>
-                      </div>
-                      <div className="rounded-xl bg-white/5 p-3">
-                        <p className="text-xs uppercase tracking-wide text-indigo-200/70">Status</p>
-                        <p className="mt-2 text-sm font-semibold text-emerald-100">{nft.status === 'selling' ? 'Listed' : 'Earning'}</p>
-                      </div>
-                    </div>
-                    <div className="flex flex-wrap gap-3">
-                      <Button
-                        variant="default"
-                        size="sm"
-                        onClick={() => handleSell(nft.id)}
-                        className="bg-gradient-to-r from-primary to-secondary"
-                      >
-                        List for sale
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleKeep(nft.id)}
-                        className="border-primary/40 text-foreground hover:bg-primary/10"
-                      >
-                        Keep earning
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          )}
-        </section>
-
-        <section className="space-y-10">
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <div className="flex items-center gap-4">
-              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-secondary/20 text-secondary-foreground">
-                <Crown className="h-6 w-6" />
-              </div>
-              <div>
-                <h2 className="text-2xl font-semibold text-foreground">Minted NFTs</h2>
-                <p className="text-sm text-foreground/80">
-                  Celebrate the memes that made it on-chain and keep an eye on collector interest.
-                </p>
-              </div>
-            </div>
-            <Button onClick={() => navigate("/marketplace")} className="bg-gradient-to-r from-secondary to-accent text-secondary-foreground shadow-lg shadow-secondary/20">
-              Visit marketplace
-            </Button>
-          </div>
-
-          {loading ? (
-            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <SkeletonTile key={i} />
-              ))}
-            </div>
-          ) : mintedNFTs.length === 0 ? (
-            <Card className="border border-dashed border-secondary/40 bg-muted/40 py-16 text-center text-secondary-foreground">
+              </CardHeader>
               <CardContent>
-                <CardTitle className="text-xl">No minted NFTs yet</CardTitle>
-                <p className="mt-3 text-sm text-foreground/80">
-                  Top-performing memes are automatically minted when they reach the spotlight.
-                </p>
+                <form className="grid gap-4" onSubmit={handleMintSubmit}>
+                  <div className="grid grid-cols-2 gap-4">
+                    <Button
+                      type="button"
+                      variant={mintForm.mode === "single" ? "default" : "outline"}
+                      onClick={() => setMintForm((prev) => ({ ...prev, mode: "single" }))}
+                    >
+                      Single (1/1)
+                    </Button>
+                    <Button
+                      type="button"
+                      variant={mintForm.mode === "collection" ? "default" : "outline"}
+                      onClick={() => setMintForm((prev) => ({ ...prev, mode: "collection" }))}
+                    >
+                      Collection
+                    </Button>
+                  </div>
+                  {mintForm.mode === "collection" && (
+                    <div>
+                      <label className="text-sm font-medium">Edition Count</label>
+                      <Input
+                        value={mintForm.editionCount}
+                        min={2}
+                        onChange={(e) => setMintForm((prev) => ({ ...prev, editionCount: e.target.value }))}
+                      />
+                    </div>
+                  )}
+                  <div>
+                    <label className="text-sm font-medium">Name</label>
+                    <Input
+                      value={mintForm.name}
+                      onChange={(e) => setMintForm((prev) => ({ ...prev, name: e.target.value }))}
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium">Symbol</label>
+                    <Input
+                      value={mintForm.symbol}
+                      onChange={(e) => setMintForm((prev) => ({ ...prev, symbol: e.target.value }))}
+                    />
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium">Description</label>
+                    <Textarea
+                      value={mintForm.description}
+                      onChange={(e) => setMintForm((prev) => ({ ...prev, description: e.target.value }))}
+                    />
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium">Royalty (bps)</label>
+                    <Input
+                      value={mintForm.royaltyBps}
+                      onChange={(e) => setMintForm((prev) => ({ ...prev, royaltyBps: e.target.value }))}
+                      placeholder="0"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium">External URL</label>
+                    <Input
+                      value={mintForm.externalUrl}
+                      onChange={(e) => setMintForm((prev) => ({ ...prev, externalUrl: e.target.value }))}
+                    />
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium">License</label>
+                    <Input
+                      value={mintForm.license}
+                      onChange={(e) => setMintForm((prev) => ({ ...prev, license: e.target.value }))}
+                    />
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium">Attributes (key:value, key:value)</label>
+                    <Input
+                      value={mintForm.attributes}
+                      onChange={(e) => setMintForm((prev) => ({ ...prev, attributes: e.target.value }))}
+                    />
+                  </div>
+                  <div className="flex justify-end gap-3 pt-4">
+                    <Button variant="outline" type="button" onClick={closeMintForm}>
+                      Cancel
+                    </Button>
+                    <Button type="submit">Mint NFT</Button>
+                  </div>
+                </form>
               </CardContent>
             </Card>
-          ) : (
-            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {mintedNFTs.map((nft) => (
-                <Card key={nft.id} className="border border-secondary/30 bg-card shadow-lg shadow-secondary/10">
-                  <CardHeader>
-                    <div className="flex items-start justify-between gap-4">
-                      {nft.imageUrl ? (
-                        <img
-                          src={nft.imageUrl}
-                          alt={nft.title}
-                          className="h-16 w-16 rounded-xl object-cover"
-                        />
-                      ) : (
-                        <div className="flex h-16 w-16 items-center justify-center rounded-xl bg-secondary/20 text-3xl">
-                          {nft.emoji}
-                        </div>
-                      )}
-                      <div className="flex-1 space-y-1">
-                        <h3 className="text-lg font-semibold text-card-foreground line-clamp-2">{nft.title}</h3>
-                        <p className="text-xs uppercase tracking-wide text-secondary/70">#{nft.id}</p>
-                      </div>
-                    </div>
-                  </CardHeader>
-                  <CardContent className="space-y-4 text-sm text-foreground/80">
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      <div className="rounded-xl bg-white/5 p-3">
-                        <p className="text-xs uppercase tracking-wide text-purple-200/70">Votes</p>
-                        <p className="mt-2 text-xl font-semibold text-amber-100">{nft.votes.toLocaleString()}</p>
-                      </div>
-                      <div className="rounded-xl bg-white/5 p-3">
-                        <p className="text-xs uppercase tracking-wide text-purple-200/70">Views</p>
-                        <p className="mt-2 text-xl font-semibold text-sky-100">{nft.views.toLocaleString()}</p>
-                      </div>
-                      <div className="rounded-xl bg-white/5 p-3">
-                        <p className="text-xs uppercase tracking-wide text-purple-200/70">Earned</p>
-                        <p className="mt-2 text-xl font-semibold text-emerald-100">{nft.earnedIcp.toFixed(4)} ICP</p>
-                      </div>
-                      <div className="rounded-xl bg-white/5 p-3">
-                        <p className="text-xs uppercase tracking-wide text-purple-200/70">Status</p>
-                        <p className="mt-2 text-sm font-semibold text-purple-100">Minted NFT</p>
-                      </div>
-                    </div>
-                    {typeof nft.listingPrice === "number" && (
-                      <div className="rounded-xl bg-white/5 p-3 text-xs text-purple-100/80">
-                        <p className="uppercase tracking-wide text-purple-200/70">Last listing</p>
-                        <p className="mt-2 text-base font-semibold text-purple-100">{nft.listingPrice.toFixed(2)} ICP</p>
-                      </div>
-                    )}
-                    <div className="flex flex-wrap gap-3">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => navigate("/marketplace")}
-                        className="border-secondary/40 text-foreground hover:bg-secondary/10"
-                      >
-                        View on marketplace
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          )}
-        </section>
-
-        <section className="space-y-6 rounded-3xl border border-primary/20 bg-card p-8 shadow-lg shadow-primary/10">
-          <div className="flex flex-wrap items-center gap-4">
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-accent/20 text-accent-foreground">
-              <MessageSquare className="h-6 w-6" />
-            </div>
-            <div>
-              <h2 className="text-2xl font-semibold text-card-foreground">Share your feedback</h2>
-              <p className="text-sm text-foreground/80">
-                Help us shape the next wave of meme tools and creator features.
-              </p>
-            </div>
           </div>
-          <FeedbackForm />
-        </section>
+        )}
+
+        {listingForm.open && (
+          <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 px-4">
+            <Card className="w-full max-w-lg border-border/60 bg-background">
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>List NFT for Sale</CardTitle>
+                <Button variant="ghost" onClick={closeListingForm}>
+                  Close
+                </Button>
+              </CardHeader>
+              <CardContent>
+                <form className="grid gap-4" onSubmit={handleListingSubmit}>
+                  <div>
+                    <label className="text-sm font-medium">Price (ICP)</label>
+                    <Input
+                      value={listingForm.price}
+                      onChange={(e) => setListingForm((prev) => ({ ...prev, price: e.target.value }))}
+                      placeholder="e.g. 1.5"
+                      required
+                    />
+                  </div>
+                  {listingForm.nft?.is_collection && (
+                    <div>
+                      <label className="text-sm font-medium">Quantity</label>
+                      <Input
+                        value={listingForm.quantity}
+                        min={1}
+                        max={listingForm.nft.owned_quantity ?? 1}
+                        onChange={(e) => setListingForm((prev) => ({ ...prev, quantity: e.target.value }))}
+                        required
+                      />
+                    </div>
+                  )}
+                  <div>
+                    <label className="text-sm font-medium">Expires In (hours, optional)</label>
+                    <Input
+                      value={listingForm.expiresHours}
+                      onChange={(e) => setListingForm((prev) => ({ ...prev, expiresHours: e.target.value }))}
+                      placeholder="Leave blank for no expiry"
+                    />
+                  </div>
+                  <div className="flex justify-end gap-3 pt-4">
+                    <Button variant="outline" type="button" onClick={closeListingForm}>
+                      Cancel
+                    </Button>
+                    <Button type="submit">Create Listing</Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+          </div>
+        )}
       </main>
     </div>
   );
-}
+};
 
-export default Portfolio
+export default Portfolio;


### PR DESCRIPTION
## Summary
- extend the canister NFT summary with marketplace metrics and expose enriched marketplace listings
- update the candid definitions and portfolio UI to surface listing status, pricing, volume, and owner metadata
- refresh the marketplace page to render the enriched listing feed with collection details and buyer actions

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68ed22d32504832b881cd8a23aef05ef