### PR TITLE
Stabilize Internet Identity login navigation

### DIFF
--- a/src/Mementic_frontend/src/Pages/Portfolio.jsx
+++ b/src/Mementic_frontend/src/Pages/Portfolio.jsx
@@ -75,6 +75,16 @@ const SkeletonTile = () => (
   </Card>
 );
 
+const LoadingState = ({ message }) => (
+  <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 text-foreground">
+    <Navigation />
+    <main className="mx-auto flex w-full max-w-4xl flex-col items-center justify-center gap-6 px-4 py-24 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full border-4 border-primary border-t-transparent animate-spin" />
+      <p className="text-sm text-muted-foreground">{message}</p>
+    </main>
+  </div>
+);
+
 const Portfolio = () => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -451,6 +461,14 @@ const Portfolio = () => {
       clearInterval(refreshInterval);
     };
   }, [isAuthenticated, loading, nfts]);
+
+  if (authLoading) {
+    return <LoadingState message="Connecting to your identity…" />;
+  }
+
+  if (!isAuthenticated) {
+    return <LoadingState message="Redirecting you to the login experience…" />;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 text-foreground">

--- a/src/Mementic_frontend/src/contexts/AuthContext.jsx
+++ b/src/Mementic_frontend/src/contexts/AuthContext.jsx
@@ -247,51 +247,76 @@ export const AuthProvider = ({ children }) => {
   };
 
   const loginWithInternetIdentity = async () => {
-    try {
-      setIsLoading(true);
-      if (!authClient) {
-        throw new Error("Auth client not initialized");
-      }
-
-      // AuthClient.login() opens a popup and returns a Promise that resolves when login is complete
-        await authClient.login({
-          identityProvider: getIdentityProvider(),
-        });
-
-        // After successful login, update state
-        const identity = authClient.getIdentity();
-        const principalText = identity.getPrincipal().toText();
-
-        setIsAuthenticated(true);
-        setPrincipal(principalText);
-        setActiveProvider("internet-identity");
-
-        // Update backend service with identity
-        await attachIdentityToBackend(identity);
-
-        // Load user profile from backend
-        const resolvedUsername = await loadUserProfile();
-      persistAuthState({
-        principal: principalText,
-        username: resolvedUsername,
-        provider: "internet-identity",
-      });
-
-      await loadUserData();
-      return true;
-    } catch (error) {
-      console.error("Internet Identity login failed:", error);
-      setIsAuthenticated(false);
-      setPrincipal(null);
-      setUsername("");
-      setActiveProvider(null);
-      setRemainingCalls(0);
-      persistAuthState(null);
-      await clearBackendAuth();
-      throw error;
-    } finally {
-      setIsLoading(false);
+    if (!authClient) {
+      throw new Error("Auth client not initialized");
     }
+
+    setIsLoading(true);
+
+    return new Promise((resolve, reject) => {
+      try {
+        authClient.login({
+          identityProvider: getIdentityProvider(),
+          onSuccess: async () => {
+          try {
+            const identity = authClient.getIdentity();
+            const principalText = identity.getPrincipal().toText();
+
+            setIsAuthenticated(true);
+            setPrincipal(principalText);
+            setActiveProvider("internet-identity");
+
+            await attachIdentityToBackend(identity);
+
+            const resolvedUsername = await loadUserProfile();
+
+            persistAuthState({
+              principal: principalText,
+              username: resolvedUsername,
+              provider: "internet-identity",
+            });
+
+            await loadUserData();
+            resolve(true);
+          } catch (error) {
+            console.error("Internet Identity post-login handling failed:", error);
+            setIsAuthenticated(false);
+            setPrincipal(null);
+            setUsername("");
+            setActiveProvider(null);
+            setRemainingCalls(0);
+            persistAuthState(null);
+            await clearBackendAuth();
+            reject(error);
+          } finally {
+            setIsLoading(false);
+          }
+        },
+        onError: async (error) => {
+          console.error("Internet Identity login failed:", error);
+          setIsAuthenticated(false);
+          setPrincipal(null);
+          setUsername("");
+          setActiveProvider(null);
+          setRemainingCalls(0);
+          persistAuthState(null);
+          await clearBackendAuth();
+          setIsLoading(false);
+          reject(error ?? new Error("Internet Identity login was cancelled"));
+        },
+      });
+      } catch (error) {
+        console.error("Internet Identity login threw before opening:", error);
+        setIsAuthenticated(false);
+        setPrincipal(null);
+        setUsername("");
+        setActiveProvider(null);
+        setRemainingCalls(0);
+        persistAuthState(null);
+        setIsLoading(false);
+        reject(error);
+      }
+    });
   };
 
   // Keep backward compatibility


### PR DESCRIPTION
## Summary
- add a reusable loading state component for the portfolio route
- block portfolio content until authentication completes or redirects back to login
- ensure Internet Identity login keeps the app in a loading state until authentication data is ready

## Testing
- npm --prefix src/Mementic_frontend run build *(fails: dfx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f08e80c374832bb03801af6e800ef3