### PR TITLE
Revamp marketplace exchange UI and listing flow

### DIFF
--- a/src/Mementic_backend/Mementic_backend.did
+++ b/src/Mementic_backend/Mementic_backend.did
@@ -104,6 +104,11 @@ type TokenRecord = record {
   has_image : bool;
   minted_at : nat64;
 };
+type ListingStrategy = variant {
+  FixedPrice : record { price_e8s : nat64 };
+  Auction : record { start_price_e8s : nat64 };
+};
+type ListingType = variant { None; FixedPrice; Auction };
 type TokenSaleMetadata = record {
   listing_price : opt nat64;
   total_sales : nat64;
@@ -114,6 +119,11 @@ type TokenSaleMetadata = record {
   last_sale_at : opt nat64;
   total_earned : nat64;
   listed_at : opt nat64;
+  listing_type : ListingType;
+  auction_start_price : opt nat64;
+  auction_highest_bid : opt nat64;
+  auction_highest_bidder : opt principal;
+  auction_bid_count : nat32;
 };
 type TopEntry = record {
   upvotes : nat32;
@@ -245,7 +255,7 @@ service : (opt InitArgs) -> {
   // Check if a meme has been minted as an NFT
   is_meme_minted : (nat64) -> (bool) query;
   // List a meme for sale on the marketplace
-  list_meme_for_sale : (nat64, nat64) -> (Result_2);
+  list_meme_for_sale : (nat64, ListingStrategy) -> (Result_2);
   mint_to : (nat64, MintingMode) -> (Result_4);
   // Store a generated meme into marketplace (associated to caller)
   publish_meme : (MemeData) -> (Result_5);

--- a/src/Mementic_backend/src/http_outcall.rs
+++ b/src/Mementic_backend/src/http_outcall.rs
@@ -17,7 +17,7 @@ use ic_stable_structures::{
 use ic_cdk::api::call::call;
 use ic_cdk::api::call::call_with_payment;
 
-use crate::nft_module::TokenSaleMetadata;
+use crate::nft_module::{ListingType, TokenSaleMetadata};
 use ic_stable_structures::storable::Bound;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -147,6 +147,12 @@ thread_local! {
 }
 
 // ---------- Data structures ----------
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub enum ListingStrategy {
+    FixedPrice { price_e8s: u64 },
+    Auction { start_price_e8s: u64 },
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, CandidType)]
 struct DayUsage {
     day: u64,
@@ -580,7 +586,7 @@ pub fn is_meme_minted(meme_id: u64) -> bool {
 
 /// List a meme for sale on the marketplace
 #[update]
-pub fn list_meme_for_sale(meme_id: u64, price_e8s: u64) -> Result<(), String> {
+pub fn list_meme_for_sale(meme_id: u64, strategy: ListingStrategy) -> Result<(), String> {
     let user = caller();
     if user == Principal::anonymous() {
         return Err("Authentication required".to_string());
@@ -596,9 +602,34 @@ pub fn list_meme_for_sale(meme_id: u64, price_e8s: u64) -> Result<(), String> {
     let token_id = crate::nft_module::get_token_by_meme_id(meme_id)
         .ok_or_else(|| "Meme has not been minted as an NFT yet".to_string())?;
 
+    let config = match strategy {
+        ListingStrategy::FixedPrice { price_e8s } => {
+            if price_e8s == 0 {
+                return Err("Listing price must be greater than zero".to_string());
+            }
+            (Some(price_e8s), ListingType::FixedPrice, None)
+        }
+        ListingStrategy::Auction { start_price_e8s } => {
+            if start_price_e8s == 0 {
+                return Err("Starting bid must be greater than zero".to_string());
+            }
+            (
+                Some(start_price_e8s),
+                ListingType::Auction,
+                Some(start_price_e8s),
+            )
+        }
+    };
+
+    let (price, listing_type, auction_start) = config;
     crate::nft_module::mutate_sale_metadata(&token_id, meme_id, |sale| {
         sale.is_listed = true;
-        sale.listing_price = Some(price_e8s);
+        sale.listing_price = price;
+        sale.listing_type = listing_type.clone();
+        sale.auction_start_price = auction_start;
+        sale.auction_highest_bid = None;
+        sale.auction_highest_bidder = None;
+        sale.auction_bid_count = 0;
         sale.listed_at = Some(time());
     });
 
@@ -625,6 +656,11 @@ pub fn remove_meme_from_market(meme_id: u64) -> Result<(), String> {
             sale.is_listed = false;
             sale.listing_price = None;
             sale.listed_at = None;
+            sale.listing_type = ListingType::None;
+            sale.auction_start_price = None;
+            sale.auction_highest_bid = None;
+            sale.auction_highest_bidder = None;
+            sale.auction_bid_count = 0;
         });
         Ok(())
     } else {
@@ -814,6 +850,11 @@ pub fn record_meme_sale(meme_id: u64, sale_price_e8s: u64) -> Result<(), String>
             sale.is_listed = false;
             sale.listing_price = None;
             sale.listed_at = None;
+            sale.listing_type = ListingType::None;
+            sale.auction_start_price = None;
+            sale.auction_highest_bid = None;
+            sale.auction_highest_bidder = None;
+            sale.auction_bid_count = 0;
         });
         Ok(())
     } else {
@@ -938,9 +979,7 @@ pub fn get_marketplace_memes() -> Vec<PublicStoredMeme> {
 // ---------- Queries ----------
 #[query]
 pub fn get_meme(meme_id: u64) -> Option<PublicStoredMeme> {
-    MEMES.with(|m| {
-        m.borrow().get(&meme_id).map(|stored| stored.into())
-    })
+    MEMES.with(|m| m.borrow().get(&meme_id).map(|stored| stored.into()))
 }
 
 #[query]

--- a/src/Mementic_backend/src/lib.rs
+++ b/src/Mementic_backend/src/lib.rs
@@ -31,6 +31,7 @@ pub use http_outcall::{
     publish_meme,
     record_meme_sale,
     remove_meme_from_market,
+    ListingStrategy,
     MemeData,
     PublicStoredMeme,
     PythonMetadata,
@@ -65,6 +66,7 @@ pub use nft_module::{
     icrc7_total_supply,
     // minting
     mint_to,
+    ListingType,
     MetadataValue,
     MintingMode,
     NftImage,

--- a/src/Mementic_backend/src/nft_module.rs
+++ b/src/Mementic_backend/src/nft_module.rs
@@ -179,6 +179,19 @@ pub struct TokenRecord {
     pub has_image: bool,           // indicates presence in STORED_IMAGES
 }
 
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub enum ListingType {
+    None,
+    FixedPrice,
+    Auction,
+}
+
+impl Default for ListingType {
+    fn default() -> Self {
+        ListingType::None
+    }
+}
+
 #[derive(Clone, Debug, Default, CandidType, Serialize, Deserialize)]
 pub struct TokenSaleMetadata {
     pub token_id: Nat,
@@ -190,6 +203,11 @@ pub struct TokenSaleMetadata {
     pub total_earned: u64,
     pub last_sale_price: Option<u64>,
     pub last_sale_at: Option<u64>,
+    pub listing_type: ListingType,
+    pub auction_start_price: Option<u64>,
+    pub auction_highest_bid: Option<u64>,
+    pub auction_highest_bidder: Option<SPrincipal>,
+    pub auction_bid_count: u32,
 }
 
 #[derive(Clone, CandidType, Deserialize)]

--- a/src/Mementic_frontend/src/Pages/Marketplace.jsx
+++ b/src/Mementic_frontend/src/Pages/Marketplace.jsx
@@ -7,7 +7,6 @@ import {
   ArrowRight,
   Flame,
   Loader2,
-  Sparkles,
   TrendingUp,
   Trophy,
 } from "lucide-react";
@@ -15,13 +14,12 @@ import { Button } from "../components/ui/Button";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/Card";
 import { Input } from "../components/ui/Input";
 import Navigation from "../components/Navigation";
+import ListingModal from "../components/ListingModal";
 import backendService from "../services/backendService";
 import { useAuth } from "../contexts/AuthContext";
 import { useToast } from "../hooks/use-toast";
 
 const trendingMemes = [];
-
-const marketCollections = [];
 
 const marketFeed = [];
 
@@ -50,6 +48,70 @@ const Marketplace = () => {
     isSubmitting: false,
     error: null,
   });
+  const [listingDialog, setListingDialog] = useState({
+    open: false,
+    winner: null,
+    isSubmitting: false,
+    error: null,
+  });
+
+  const unwrapOptional = (value) =>
+    Array.isArray(value) ? (value.length ? value[0] : null) : value ?? null;
+
+  const toIcp = (value) => {
+    const raw = unwrapOptional(value);
+    if (raw == null) return null;
+    if (typeof raw === "bigint") {
+      return Number(raw) / 100000000;
+    }
+    const num = Number(raw);
+    return Number.isFinite(num) ? num / 100000000 : null;
+  };
+
+  const parseSaleMetadata = (raw) => {
+    if (!raw) return null;
+    let listingType = "None";
+    if (raw.listing_type && typeof raw.listing_type === "object") {
+      const keys = Object.keys(raw.listing_type);
+      if (keys.length) {
+        listingType = keys[0];
+      }
+    }
+
+    return {
+      isListed: Boolean(raw.is_listed),
+      listingType,
+      listingPriceIcp: toIcp(raw.listing_price),
+      auctionStartIcp: toIcp(raw.auction_start_price),
+      auctionHighestIcp: toIcp(raw.auction_highest_bid),
+      bidCount: Number(raw.auction_bid_count ?? 0),
+      raw,
+    };
+  };
+
+  const formatIcpValue = (value) => {
+    if (value == null) return "—";
+    const display = Number(value);
+    if (!Number.isFinite(display)) return "—";
+    if (display >= 1) return display.toFixed(2);
+    return display.toFixed(4);
+  };
+
+  const formatListingStatus = (snapshot) => {
+    if (!snapshot || !snapshot.isListed) {
+      return "Not listed";
+    }
+    if (snapshot.listingType === "FixedPrice") {
+      const price = formatIcpValue(snapshot.listingPriceIcp);
+      return `Fixed · ${price} ICP`;
+    }
+    if (snapshot.listingType === "Auction") {
+      const start = formatIcpValue(snapshot.auctionStartIcp);
+      const bids = snapshot.bidCount > 0 ? `${snapshot.bidCount} bids` : "0 bids";
+      return `Auction · ${start} ICP · ${bids}`;
+    }
+    return "Not listed";
+  };
 
   const normalizeMintedTokens = (tokens) =>
     Array.isArray(tokens)
@@ -93,6 +155,16 @@ const Marketplace = () => {
             try {
               const meme = await backendService.getMeme(entry.meme_id);
               const mintedTokens = await backendService.getMintedTokens(entry.meme_id);
+              let saleMetadata = null;
+              try {
+                saleMetadata = await backendService.getSaleMetadataForMeme(entry.meme_id);
+              } catch (saleError) {
+                console.warn(
+                  "Failed to fetch sale metadata for winner",
+                  entry?.meme_id,
+                  saleError
+                );
+              }
               const captionField = meme?.meme_data?.caption;
               const caption = Array.isArray(captionField)
                 ? captionField[0]
@@ -120,6 +192,7 @@ const Marketplace = () => {
                   (prompt && String(prompt).trim()) ||
                   `Meme #${entry.meme_id}`,
                 mintedTokens: normalizeMintedTokens(mintedTokens),
+                saleSnapshot: parseSaleMetadata(saleMetadata),
               };
             } catch (innerError) {
               console.warn("Failed to enrich winner", entry?.meme_id, innerError);
@@ -133,6 +206,7 @@ const Marketplace = () => {
                 prompt: "",
                 title: `Meme #${entry.meme_id}`,
                 mintedTokens: [],
+                saleSnapshot: null,
               };
             }
           })
@@ -188,6 +262,17 @@ const Marketplace = () => {
     return mintedCount === 0 && winner.ownerPrincipal === principal;
   };
 
+  const canListWinner = (winner) => {
+    if (!winner) return false;
+    if (!isAuthenticated || authLoading) return false;
+    if (!principal) return false;
+    const mintedCount = winner.mintedTokens?.length ?? 0;
+    if (mintedCount === 0) return false;
+    if (winner.ownerPrincipal !== principal) return false;
+    if (winner.saleSnapshot?.isListed) return false;
+    return true;
+  };
+
   const openMintDialog = (winner) => {
     if (!winner) return;
     setMintDialog({
@@ -209,6 +294,69 @@ const Marketplace = () => {
       isSubmitting: false,
       error: null,
     });
+  };
+
+  const openListingDialog = (winner) => {
+    if (!winner) return;
+    setListingDialog({
+      open: true,
+      winner,
+      isSubmitting: false,
+      error: null,
+    });
+  };
+
+  const closeListingDialog = () => {
+    setListingDialog({
+      open: false,
+      winner: null,
+      isSubmitting: false,
+      error: null,
+    });
+  };
+
+  const handleListingSubmit = async (memeId, options = {}) => {
+    if (!memeId) return;
+    try {
+      setListingDialog((prev) => ({ ...prev, isSubmitting: true, error: null }));
+      const idText = typeof memeId === "string" ? memeId : String(memeId);
+      if (!/^\d+$/.test(idText)) {
+        throw new Error("Invalid meme identifier for listing");
+      }
+
+      await backendService.listMemeForSale(BigInt(idText), options);
+      toast({
+        title: "Listing published",
+        description: "Your meme NFT is now trading on the marketplace.",
+      });
+
+      let refreshedSnapshot = null;
+      try {
+        const refreshed = await backendService.getSaleMetadataForMeme(BigInt(idText));
+        refreshedSnapshot = parseSaleMetadata(refreshed);
+      } catch (refreshError) {
+        console.warn("Failed to refresh sale metadata:", refreshError);
+      }
+
+      const numericId = Number(idText);
+      setTopWinners((prev) =>
+        prev.map((entry) =>
+          entry.memeId === numericId
+            ? { ...entry, saleSnapshot: refreshedSnapshot ?? entry.saleSnapshot }
+            : entry
+        )
+      );
+
+      closeListingDialog();
+    } catch (error) {
+      console.error("Listing submission failed:", error);
+      setListingDialog((prev) => ({
+        ...prev,
+        error: error?.message ?? "Failed to list NFT",
+      }));
+    } finally {
+      setListingDialog((prev) => ({ ...prev, isSubmitting: false }));
+    }
   };
 
   const handleMintModeChange = (mode) => {
@@ -292,6 +440,13 @@ const Marketplace = () => {
   const modalWinner = mintDialog.winner;
   const modalMintedCount = modalWinner?.mintedTokens?.length ?? 0;
   const allowMintAction = modalWinner ? canMintWinner(modalWinner) && modalMintedCount === 0 : false;
+  const listingTarget = listingDialog.winner
+    ? {
+        id: listingDialog.winner.memeId,
+        title: listingDialog.winner.title,
+        imageUrl: listingDialog.winner.imageUrl,
+      }
+    : null;
 
   useEffect(() => {
     if (totalSlides > 1) {
@@ -316,6 +471,45 @@ const Marketplace = () => {
     });
   };
 
+  const tickerItems = useMemo(
+    () =>
+      topWinners.map((winner) => {
+        const listing = winner.saleSnapshot;
+        const priceDisplay = listing
+          ? listing.listingType === "FixedPrice"
+            ? `${formatIcpValue(listing.listingPriceIcp)} ICP`
+            : listing.listingType === "Auction"
+            ? `${formatIcpValue(listing.auctionStartIcp)} ICP`
+            : "—"
+          : "—";
+
+        return {
+          id: winner.memeId,
+          rank: winner.rank,
+          title: winner.title,
+          votes: winner.upvotes,
+          minted: winner.mintedTokens?.length ?? 0,
+          listingLabel: formatListingStatus(listing),
+          priceDisplay,
+        };
+      }),
+    [topWinners]
+  );
+
+  const exchangeSummary = useMemo(() => {
+    const totalVotes = topWinners.reduce(
+      (sum, winner) => sum + Number(winner.upvotes ?? 0),
+      0
+    );
+    const listed = topWinners.filter((winner) => winner.saleSnapshot?.isListed)
+      .length;
+    const minted = topWinners.reduce(
+      (sum, winner) => sum + (winner.mintedTokens?.length ?? 0),
+      0
+    );
+    return { totalVotes, listed, minted };
+  }, [topWinners]);
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-gradient-background text-foreground">
       <div className="pointer-events-none absolute inset-0 opacity-70">
@@ -327,29 +521,81 @@ const Marketplace = () => {
       <Navigation />
 
       <main className="relative z-10">
-        <section className="px-5 pb-4 pt-16 sm:px-8">
-          <div className="mx-auto flex max-w-5xl flex-col items-center text-center">
-            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
-              <Flame className="h-4 w-4 text-primary" />
-              Meme Marketplace
-            </span>
-            <h1 className="mt-6 text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
-              Discover and trade the hottest meme NFTs
-            </h1>
-            <p className="mt-6 text-lg text-muted-foreground sm:max-w-2xl">
-              Browse live auctions, vote on trending memes, and collect verified NFT drops from the Mementic ecosystem.
-            </p>
-            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-              <Link to="/myplace">
-                <Button variant="hero" size="xl" className="px-10">
-                  Create Your Meme
-                </Button>
-              </Link>
-              <Link to="/auction">
-                <Button variant="outline" size="lg" className="rounded-full border-border/60 bg-background/70">
-                  View Live Auctions
-                </Button>
-              </Link>
+        <section className="px-5 pb-8 pt-16 sm:px-8">
+          <div className="mx-auto w-full max-w-6xl space-y-8">
+            <div className="grid gap-8 lg:grid-cols-[1.2fr,0.8fr]">
+              <div className="space-y-6 text-left">
+                <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+                  <Flame className="h-4 w-4 text-primary" />
+                  Meme Exchange
+                </span>
+                <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
+                  Trade meme NFTs like it’s the opening bell
+                </h1>
+                <p className="text-lg text-muted-foreground sm:max-w-2xl">
+                  Monitor live drops, lock in fixed prices, or launch auctions with starting bids that feel like a trading floor.
+                  Every weekly winner can mint and list directly without leaving the exchange view.
+                </p>
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <Link to="/myplace">
+                    <Button variant="hero" size="xl" className="px-10">
+                      Mint a Meme NFT
+                    </Button>
+                  </Link>
+                  <Link to="/auction">
+                    <Button variant="outline" size="lg" className="rounded-full border-border/60 bg-background/70">
+                      View Live Auctions
+                    </Button>
+                  </Link>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
+                    <p className="text-xs uppercase tracking-[0.3em] text-muted-foreground">Total votes this week</p>
+                    <p className="mt-2 text-2xl font-semibold text-foreground">{exchangeSummary.totalVotes.toLocaleString()}</p>
+                  </div>
+                  <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
+                    <p className="text-xs uppercase tracking-[0.3em] text-muted-foreground">NFT editions minted</p>
+                    <p className="mt-2 text-2xl font-semibold text-foreground">{exchangeSummary.minted}</p>
+                  </div>
+                  <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
+                    <p className="text-xs uppercase tracking-[0.3em] text-muted-foreground">Listings live</p>
+                    <p className="mt-2 text-2xl font-semibold text-foreground">{exchangeSummary.listed}</p>
+                  </div>
+                </div>
+              </div>
+              <div className="flex h-full flex-col overflow-hidden rounded-3xl border border-border/60 bg-background/70">
+                <div className="flex items-center justify-between border-b border-border/40 px-5 py-4 text-xs uppercase tracking-[0.3em] text-muted-foreground">
+                  <span>Live order tape</span>
+                  <span>{new Date().toLocaleTimeString()}</span>
+                </div>
+                <div className="divide-y divide-border/50">
+                  {tickerItems.length > 0 ? (
+                    tickerItems.map((item) => (
+                      <div
+                        key={item.id}
+                        className="flex items-center justify-between px-5 py-4 transition hover:bg-background/60"
+                      >
+                        <div>
+                          <p className="text-sm font-semibold text-foreground">{item.title}</p>
+                          <p className="text-xs text-muted-foreground">
+                            #{item.rank} • {item.listingLabel}
+                          </p>
+                        </div>
+                        <div className="text-right">
+                          <p className="text-sm font-semibold text-primary">{item.priceDisplay}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {item.votes.toLocaleString()} votes • {item.minted} minted
+                          </p>
+                        </div>
+                      </div>
+                    ))
+                  ) : (
+                    <div className="px-5 py-8 text-center text-sm text-muted-foreground">
+                      Mint a meme winner to populate today’s trading tape.
+                    </div>
+                  )}
+                </div>
+              </div>
             </div>
           </div>
         </section>
@@ -465,96 +711,82 @@ const Marketplace = () => {
                       {winnersError}
                     </div>
                   ) : topWinners.length > 0 ? (
-                    topWinners.map((winner) => {
-                      const mintedCount = winner.mintedTokens?.length ?? 0;
-                      const canMint = canMintWinner(winner);
-                      return (
-                        <div
-                          key={winner.memeId}
-                          className="flex flex-col gap-4 rounded-2xl border border-border/60 bg-background/70 p-4 transition hover:border-primary/50 hover:bg-background/80"
-                        >
-                          <div className="flex flex-wrap items-center gap-4">
-                            <span className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 font-semibold text-primary">
-                              #{winner.rank}
-                            </span>
-                            {winner.imageUrl ? (
-                              <div className="h-16 w-16 overflow-hidden rounded-xl border border-border/60">
-                                <img
-                                  src={winner.imageUrl}
-                                  alt={winner.title}
-                                  className="h-full w-full object-cover"
-                                  loading="lazy"
-                                />
-                              </div>
-                            ) : null}
-                            <div className="min-w-[12rem] flex-1">
-                              <p className="text-base font-semibold text-foreground">{winner.title}</p>
-                              <p className="text-xs uppercase tracking-[0.3em] text-muted-foreground">
-                                Owner · {shortPrincipal(winner.ownerPrincipal)}
-                              </p>
-                            </div>
-                            <div className="flex flex-col items-end gap-1 text-xs text-muted-foreground">
-                              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 font-semibold text-primary">
-                                <TrendingUp className="h-3.5 w-3.5" />
-                                {winner.upvotes.toLocaleString()} votes
-                              </span>
-                              {mintedCount > 0 ? (
-                                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1 font-semibold text-emerald-300">
-                                  <Sparkles className="h-3.5 w-3.5" />
-                                  Minted · {mintedCount} {mintedCount === 1 ? "edition" : "editions"}
-                                </span>
-                              ) : null}
-                            </div>
-                          </div>
-                          <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
-                            <span>
-                              Meme ID #{winner.memeId}
-                              {latestWeek?.week_id !== undefined && (
-                                <>
-                                  {" "}• Week {Number(latestWeek.week_id)}
-                                </>
-                              )}
-                            </span>
-                            {latestWeek?.end_time ? (
-                              <span className="text-muted-foreground/80">
-                                Finalized {formatTimestamp(latestWeek.end_time)}
-                              </span>
-                            ) : null}
-                          </div>
-                          <div className="flex flex-wrap gap-3">
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              className="border border-border/60 bg-background/70"
-                              onClick={() => openMintDialog(winner)}
-                              disabled={!canMint}
-                            >
-                              {canMint ? "Convert to NFT" : mintedCount > 0 ? "Already minted" : "Minting locked"}
-                            </Button>
-                            {mintedCount > 0 ? (
-                              <Button
-                                type="button"
-                                variant="outline"
-                                className="border-border/60 text-xs"
-                                onClick={() => openMintDialog(winner)}
-                              >
-                                View mint details
-                              </Button>
-                            ) : null}
-                          </div>
-                          {!isAuthenticated && (
-                            <p className="text-xs text-muted-foreground">
-                              Login to mint your winning meme as an NFT.
-                            </p>
-                          )}
-                          {canMint && !mintedCount && (
-                            <p className="text-xs text-foreground/80">
-                              You earned the top spot—choose between a single masterpiece or a limited collection when you mint.
-                            </p>
-                          )}
-                        </div>
-                      );
-                    })
+                    <div className="overflow-hidden rounded-2xl border border-border/60 bg-background/70">
+                      <table className="min-w-full divide-y divide-border/50 text-left text-sm">
+                        <thead className="bg-background/60 text-xs uppercase tracking-[0.3em] text-muted-foreground">
+                          <tr>
+                            <th className="px-4 py-3 font-medium">Asset</th>
+                            <th className="px-4 py-3 font-medium">Rank</th>
+                            <th className="px-4 py-3 font-medium">Votes</th>
+                            <th className="px-4 py-3 font-medium">Minted</th>
+                            <th className="px-4 py-3 font-medium">Listing</th>
+                            <th className="px-4 py-3 font-medium text-right">Actions</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-border/40">
+                          {topWinners.map((winner) => {
+                            const mintedCount = winner.mintedTokens?.length ?? 0;
+                            const canMint = canMintWinner(winner);
+                            const canList = canListWinner(winner);
+                            const listingLabel = formatListingStatus(winner.saleSnapshot);
+                            return (
+                              <tr key={winner.memeId} className="transition hover:bg-background/60">
+                                <td className="px-4 py-4">
+                                  <div className="flex items-center gap-3">
+                                    {winner.imageUrl ? (
+                                      <div className="h-12 w-12 overflow-hidden rounded-xl border border-border/60">
+                                        <img
+                                          src={winner.imageUrl}
+                                          alt={winner.title}
+                                          className="h-full w-full object-cover"
+                                          loading="lazy"
+                                        />
+                                      </div>
+                                    ) : (
+                                      <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-border/60 bg-background/80 text-lg">
+                                        🖼️
+                                      </div>
+                                    )}
+                                    <div>
+                                      <p className="text-sm font-semibold text-foreground">{winner.title}</p>
+                                      <p className="text-xs uppercase tracking-[0.3em] text-muted-foreground">
+                                        Owner · {shortPrincipal(winner.ownerPrincipal)}
+                                      </p>
+                                    </div>
+                                  </div>
+                                </td>
+                                <td className="px-4 py-4 text-sm font-semibold text-primary">#{winner.rank}</td>
+                                <td className="px-4 py-4 text-sm text-foreground">{winner.upvotes.toLocaleString()}</td>
+                                <td className="px-4 py-4 text-sm text-foreground">{mintedCount > 0 ? mintedCount : "—"}</td>
+                                <td className="px-4 py-4 text-xs text-muted-foreground">{listingLabel}</td>
+                                <td className="px-4 py-4">
+                                  <div className="flex flex-wrap items-center justify-end gap-2">
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      className="border border-border/60 bg-background/70"
+                                      onClick={() => openMintDialog(winner)}
+                                      disabled={!canMint}
+                                    >
+                                      {canMint ? "Mint NFT" : mintedCount > 0 ? "Minted" : "Mint locked"}
+                                    </Button>
+                                    <Button
+                                      type="button"
+                                      variant="outline"
+                                      className="border-border/60"
+                                      onClick={() => openListingDialog(winner)}
+                                      disabled={!canList}
+                                    >
+                                      {winner.saleSnapshot?.isListed ? "Listed" : "List to market"}
+                                    </Button>
+                                  </div>
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
                   ) : (
                     <p className="text-sm text-muted-foreground">
                       Top winners will appear once a weekly voting round completes.
@@ -596,45 +828,44 @@ const Marketplace = () => {
                 </div>
               </CardHeader>
               <CardContent className="overflow-x-auto">
-                {marketCollections.length > 0 ? (
+                {tickerItems.length > 0 ? (
                   <table className="min-w-full divide-y divide-border text-left text-sm">
                     <thead className="uppercase tracking-[0.3em] text-muted-foreground">
                       <tr>
-                        <th className="py-3 pr-4 font-medium">Ranking</th>
-                        <th className="py-3 pr-4 font-medium">Collection Name</th>
-                        <th className="py-3 pr-4 font-medium">Top Offer</th>
-                        <th className="py-3 pr-4 font-medium">Volume</th>
-                        <th className="py-3 pr-4 font-medium">Floor</th>
-                        <th className="py-3 pr-4 font-medium">Price</th>
+                        <th className="py-3 pr-4 font-medium">Meme</th>
+                        <th className="py-3 pr-4 font-medium">Last Price</th>
+                        <th className="py-3 pr-4 font-medium">Votes</th>
+                        <th className="py-3 pr-4 font-medium">Minted</th>
+                        <th className="py-3 pr-4 font-medium">Status</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-border/60">
-                      {marketCollections.map((collection) => (
-                        <tr key={collection.rank} className="transition hover:bg-background/50">
-                          <td className="whitespace-nowrap py-4 pr-4 font-semibold text-muted-foreground">
-                            #{collection.rank}
+                      {tickerItems.map((item) => (
+                        <tr key={`order-${item.id}`} className="transition hover:bg-background/50">
+                          <td className="whitespace-nowrap py-4 pr-4 text-foreground">
+                            #{item.rank} · {item.title}
+                          </td>
+                          <td className="whitespace-nowrap py-4 pr-4 font-semibold text-primary">
+                            {item.priceDisplay}
                           </td>
                           <td className="whitespace-nowrap py-4 pr-4 text-foreground">
-                            {collection.name}
+                            {item.votes.toLocaleString()}
                           </td>
-                          <td className="whitespace-nowrap py-4 pr-4 text-foreground">
-                            {collection.topOffer}
-                          </td>
-                          <td className="whitespace-nowrap py-4 pr-4 text-foreground">
-                            {collection.volume}
-                          </td>
-                          <td className="whitespace-nowrap py-4 pr-4 text-primary">
-                            {collection.floor}
-                          </td>
-                          <td className="whitespace-nowrap py-4 pr-4 text-foreground">
-                            {collection.price}
-                          </td>
+                          <td className="whitespace-nowrap py-4 pr-4 text-foreground">{item.minted}</td>
+                          <td className="whitespace-nowrap py-4 pr-4 text-muted-foreground">{item.listingLabel}</td>
                         </tr>
                       ))}
                     </tbody>
                   </table>
                 ) : (
-                  <p className="text-sm text-muted-foreground py-8 text-center">No market data available yet.</p>
+                  <p className="py-8 text-center text-sm text-muted-foreground">
+                    Waiting for fresh listings. Mint a champion to open the order book.
+                  </p>
+                )}
+                {!isAuthenticated && (
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    Connect your wallet to mint and stream your winners directly to the exchange board.
+                  </p>
                 )}
               </CardContent>
             </Card>
@@ -788,6 +1019,14 @@ const Marketplace = () => {
             </Card>
           </div>
         ) : null}
+        <ListingModal
+          isOpen={listingDialog.open}
+          onClose={closeListingDialog}
+          nft={listingTarget}
+          onConfirm={handleListingSubmit}
+          isProcessing={listingDialog.isSubmitting}
+          error={listingDialog.error}
+        />
       </main>
     </div>
   );

--- a/src/Mementic_frontend/src/Pages/Portfolio.jsx
+++ b/src/Mementic_frontend/src/Pages/Portfolio.jsx
@@ -651,13 +651,21 @@ const Portfolio = () => {
         throw new Error("Invalid meme identifier for listing");
       }
 
-      const price = Number(options.price);
-      if (!Number.isFinite(price) || price <= 0) {
-        throw new Error("Listing requires a positive price");
+      const mode = (options.mode || options.auctionType) === "timed_auction" ? "auction" : (options.mode || "fixed");
+
+      if (mode === "auction") {
+        const startBid = Number(options.startingBid ?? options.price);
+        if (!Number.isFinite(startBid) || startBid <= 0) {
+          throw new Error("Auction listings require a positive starting bid");
+        }
+      } else {
+        const price = Number(options.price);
+        if (!Number.isFinite(price) || price <= 0) {
+          throw new Error("Listing requires a positive price");
+        }
       }
 
-      const priceE8s = BigInt(Math.round(price * 100000000));
-      await backendService.listMemeForSale(BigInt(idAsString), priceE8s);
+      await backendService.listMemeForSale(BigInt(idAsString), options);
       toast({
         title: "Listing created successfully!",
         description: "Your NFT is now visible on the marketplace.",

--- a/src/Mementic_frontend/src/components/ListingModal.jsx
+++ b/src/Mementic_frontend/src/components/ListingModal.jsx
@@ -2,28 +2,47 @@ import { useEffect, useState } from "react";
 import { Button } from "./ui/Button";
 import { Input } from "./ui/Input";
 
-const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false }) => {
+const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false, error = null }) => {
+  const [mode, setMode] = useState("fixed");
   const [price, setPrice] = useState("");
-  const [auctionType, setAuctionType] = useState("fixed_price");
+  const [startingBid, setStartingBid] = useState("");
   const [duration, setDuration] = useState("7"); // days
   const [royalties, setRoyalties] = useState("5");
+  const [formError, setFormError] = useState(null);
 
   useEffect(() => {
     if (isOpen) {
+      setMode("fixed");
       setPrice("");
-      setAuctionType("fixed_price");
+      setStartingBid("");
       setDuration("7");
       setRoyalties("5");
+      setFormError(null);
     }
   }, [isOpen]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    setFormError(null);
+
+    const rawValue = mode === "auction" ? startingBid : price;
+    const numeric = Number.parseFloat(rawValue);
+
+    if (!Number.isFinite(numeric) || numeric <= 0) {
+      setFormError(
+        mode === "auction"
+          ? "Starting bid must be greater than zero."
+          : "Listing price must be greater than zero."
+      );
+      return;
+    }
 
     const listingOptions = {
-      price: parseFloat(price),
-      auctionType: auctionType === "fixed_price" ? null : auctionType,
-      duration: auctionType === "timed_auction" ? parseInt(duration) : null,
+      mode,
+      price: numeric,
+      startingBid: mode === "auction" ? numeric : null,
+      auctionType: mode === "auction" ? "timed_auction" : null,
+      duration: mode === "auction" ? parseInt(duration) : null,
       royalties: parseInt(royalties) || null,
     };
 
@@ -33,13 +52,13 @@ const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false })
   if (!isOpen || !nft) return null;
 
   return (
-    <div className={`fixed inset-0 z-50 flex items-center justify-center ${isOpen ? '' : 'hidden'}`}>
+    <div className={`fixed inset-0 z-50 flex items-center justify-center ${isOpen ? "" : "hidden"}`}>
       <div className="fixed inset-0 bg-black/50" onClick={onClose} />
       <div className="relative bg-background rounded-lg shadow-lg max-w-md w-full mx-4 max-h-[90vh] overflow-y-auto">
         <div className="p-6">
-          <h2 className="text-lg font-semibold mb-4">List NFT on Marketplace</h2>
+          <h2 className="text-lg font-semibold mb-4">Launch NFT Listing</h2>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
             <h3 className="font-semibold text-sm">NFT Preview</h3>
             <div className="flex items-center gap-3 p-3 bg-muted rounded-lg">
@@ -63,13 +82,55 @@ const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false })
 
           <div className="space-y-4">
             <div>
-              <label className="text-sm font-medium">Price (ICP)</label>
+              <label className="text-sm font-medium">Listing Mode</label>
+              <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
+                <button
+                  type="button"
+                  onClick={() => setMode("fixed")}
+                  disabled={isProcessing}
+                  className={`rounded-md border px-3 py-2 text-left ${
+                    mode === "fixed"
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-input hover:border-primary/40"
+                  }`}
+                >
+                  <span className="block font-semibold">Fixed price</span>
+                  <span className="block text-xs text-muted-foreground">
+                    Set a buy-now price for collectors.
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMode("auction")}
+                  disabled={isProcessing}
+                  className={`rounded-md border px-3 py-2 text-left ${
+                    mode === "auction"
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-input hover:border-primary/40"
+                  }`}
+                >
+                  <span className="block font-semibold">Auction</span>
+                  <span className="block text-xs text-muted-foreground">
+                    Kick off live bidding with a floor price.
+                  </span>
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label className="text-sm font-medium">
+                {mode === "auction" ? "Starting bid (ICP)" : "Listing price (ICP)"}
+              </label>
               <Input
                 type="number"
                 step="0.01"
                 min="0.01"
-                value={price}
-                onChange={(e) => setPrice(e.target.value)}
+                value={mode === "auction" ? startingBid : price}
+                onChange={(e) =>
+                  mode === "auction"
+                    ? setStartingBid(e.target.value)
+                    : setPrice(e.target.value)
+                }
                 placeholder="0.00"
                 required
                 className="mt-1"
@@ -77,20 +138,7 @@ const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false })
               />
             </div>
 
-            <div>
-              <label className="text-sm font-medium">Auction Type</label>
-              <select
-                value={auctionType}
-                onChange={(e) => setAuctionType(e.target.value)}
-                className="w-full mt-1 px-3 py-2 border border-input bg-background rounded-md text-sm"
-                disabled={isProcessing}
-              >
-                <option value="fixed_price">Fixed Price</option>
-                <option value="timed_auction">Timed Auction</option>
-              </select>
-            </div>
-
-            {auctionType === "timed_auction" && (
+            {mode === "auction" && (
               <div>
                 <label className="text-sm font-medium">Duration (days)</label>
                 <Input
@@ -123,6 +171,12 @@ const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false })
             </div>
           </div>
 
+          {formError || error ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive">
+              {formError || error}
+            </div>
+          ) : null}
+
           <div className="flex gap-3 pt-4">
             <Button type="button" variant="outline" onClick={onClose} className="flex-1">
               Cancel
@@ -135,7 +189,7 @@ const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false })
               {isProcessing ? "Listing…" : "List NFT"}
             </Button>
           </div>
-        </form>
+          </form>
         </div>
       </div>
     </div>

--- a/src/Mementic_frontend/src/hooks/useMarketplaceData.js
+++ b/src/Mementic_frontend/src/hooks/useMarketplaceData.js
@@ -5,7 +5,7 @@ import {
   safeBigIntToNumber,
   toOptionalBigInt,
   normalizeMeme,
-  getWeekStartIST,
+  deriveWeekIdFromMs,
 } from "../utils/marketplaceUtils";
 
 export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, searchQuery) => {
@@ -15,6 +15,31 @@ export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, 
   const [loadingTop, setLoadingTop] = useState(true);
   const [loadingList, setLoadingList] = useState(true);
   const [errorMsg, setErrorMsg] = useState("");
+  const [currentWeekId, setCurrentWeekId] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        await backendService.ensureReady();
+        const status = await backendService.getCurrentWeekStatus();
+        if (!cancelled) {
+          const weekId = Number(status?.weekId);
+          setCurrentWeekId(Number.isFinite(weekId) ? weekId : null);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.warn("Failed to fetch current week status:", error);
+          setCurrentWeekId(null);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Fetch Top 3
   useEffect(() => {
@@ -85,7 +110,15 @@ export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, 
             voteDetails: e?.votes ?? null,
           };
         });
-        if (!cancelled) setTopMemes(arr);
+        const filtered =
+          currentWeekId == null
+            ? arr
+            : arr.filter((meme) => {
+                const week = deriveWeekIdFromMs(meme?.created_at);
+                return week == null || week >= currentWeekId;
+              });
+
+        if (!cancelled) setTopMemes(filtered);
       } catch (e) {
         if (!cancelled) setErrorMsg("Failed to load top memes.");
       } finally {
@@ -95,7 +128,7 @@ export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, 
     return () => {
       cancelled = true;
     };
-  }, [hasProfileName, isAuthenticated]);
+  }, [hasProfileName, isAuthenticated, currentWeekId]);
 
   // Fetch paginated list
   const fetchList = async ({ reset = false } = {}) => {
@@ -278,14 +311,19 @@ export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, 
       }
 
       // Filter to current week only (cleanup old memes)
-      const weekStart = getWeekStartIST();
-      arr = arr.filter(m => m.created_at >= weekStart.getTime());
+      const filteredByWeek =
+        currentWeekId == null
+          ? arr
+          : arr.filter((meme) => {
+              const week = deriveWeekIdFromMs(meme?.created_at);
+              return week == null || week >= currentWeekId;
+            });
 
       // Client-side paging
       const start = (page - 1) * 12; // PAGE_SIZE = 12
-      const slice = arr.slice(start, start + 12);
+      const slice = filteredByWeek.slice(start, start + 12);
 
-      setTotal(arr.length);
+      setTotal(filteredByWeek.length);
       setMemes((prev) =>
         page === 1 || reset ? slice : [...ensureArray(prev), ...slice]
       );
@@ -342,13 +380,13 @@ export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, 
 
   useEffect(() => {
     fetchList({ reset: page === 1 });
-  }, [page, sort]);
+  }, [page, sort, currentWeekId]);
 
   useEffect(() => {
     if (isAuthenticated && hasProfileName) {
       fetchList({ reset: true });
     }
-  }, [isAuthenticated, hasProfileName]);
+  }, [isAuthenticated, hasProfileName, currentWeekId]);
 
   return {
     topMemes,

--- a/src/Mementic_frontend/src/services/backendService.js
+++ b/src/Mementic_frontend/src/services/backendService.js
@@ -621,6 +621,43 @@ class BackendService {
   }
 
   /**
+   * Get the status for the active voting week
+   */
+  async getCurrentWeekStatus() {
+    const result = await this._safeCall('get_current_week_status');
+    if (!Array.isArray(result) || result.length < 4) {
+      return {
+        weekId: 0,
+        remainingNs: 0,
+        endTimeNs: 0,
+        isCompleted: false,
+      };
+    }
+
+    const [rawWeekId, rawRemaining, rawEndTime, completed] = result;
+    const toNumber = (value) => {
+      if (typeof value === 'bigint') {
+        const max = BigInt(Number.MAX_SAFE_INTEGER);
+        if (value > max) return Number.MAX_SAFE_INTEGER;
+        if (value < BigInt(0)) return 0;
+        return Number(value);
+      }
+      if (Array.isArray(value) && value.length) {
+        return toNumber(value[0]);
+      }
+      const n = Number(value);
+      return Number.isFinite(n) ? n : 0;
+    };
+
+    return {
+      weekId: toNumber(rawWeekId),
+      remainingNs: toNumber(rawRemaining),
+      endTimeNs: toNumber(rawEndTime),
+      isCompleted: Boolean(completed),
+    };
+  }
+
+  /**
     * Get user's vote on a specific meme
     */
   async getUserVote(memeId) {
@@ -650,11 +687,35 @@ class BackendService {
   /**
      * List a meme for sale
      */
-  async listMemeForSale(memeId, priceE8s) {
+  async listMemeForSale(memeId, options = {}) {
     if (!this.isAuthenticated) {
       throw new Error("Authentication required: Please login to list memes");
     }
-    const result = await this._safeCall('list_meme_for_sale', memeId, priceE8s);
+    const mode = (options.mode || options.type || "fixed_price").toLowerCase();
+
+    const ensurePositive = (value, label) => {
+      const num = Number(value);
+      if (!Number.isFinite(num) || num <= 0) {
+        throw new Error(`${label} must be greater than zero`);
+      }
+      return num;
+    };
+
+    let strategy;
+    if (mode === "auction" || mode === "timed_auction") {
+      const start = ensurePositive(
+        options.startingBid ?? options.startPrice ?? options.price,
+        "Starting bid"
+      );
+      const startE8s = BigInt(Math.round(start * 100000000));
+      strategy = { Auction: { start_price_e8s: startE8s } };
+    } else {
+      const price = ensurePositive(options.price, "Listing price");
+      const priceE8s = BigInt(Math.round(price * 100000000));
+      strategy = { FixedPrice: { price_e8s: priceE8s } };
+    }
+
+    const result = await this._safeCall('list_meme_for_sale', memeId, strategy);
     return this._unwrapResult(result, "list_meme_for_sale failed");
   }
 
@@ -675,6 +736,14 @@ class BackendService {
   async recordMemeSale(memeId, salePriceE8s) {
     const result = await this._safeCall('record_meme_sale', memeId, salePriceE8s);
     return this._unwrapResult(result, "record_meme_sale failed");
+  }
+
+  /**
+   * Get sale metadata for a meme (if minted)
+   */
+  async getSaleMetadataForMeme(memeId) {
+    const result = await this._safeCall('get_sale_metadata_for_meme', memeId);
+    return this._fromOpt(result);
   }
 
   /**

--- a/src/Mementic_frontend/src/utils/marketplaceUtils.js
+++ b/src/Mementic_frontend/src/utils/marketplaceUtils.js
@@ -68,6 +68,14 @@ export const formatIcp = (value) => {
   return n.toFixed(4);
 };
 
+export const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const deriveWeekIdFromMs = (ms) => {
+  const value = Number(ms);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return Math.floor(value / WEEK_IN_MS);
+};
+
 export const normalizeMeme = (m, extra = {}, userProfiles = new Map()) => {
   // Supports PublicStoredMeme { id, owner, meme_data{...}, created_at, ... }
   const md = m?.meme_data || m;


### PR DESCRIPTION
## Summary
- redesign the marketplace landing experience to mimic a live exchange with ticker summaries and updated winner table
- allow weekly winners to list minted memes with fixed-price or auction starting bids directly from the marketplace and portfolio views
- extend backend sale metadata to capture listing type information and reset client data between weekly battles

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f20322ddf8832b9e9f8c64df0470be