### PR TITLE
Separate marketplace and auction listing flows

### DIFF
--- a/src/Mementic_frontend/src/Pages/Marketplace.jsx
+++ b/src/Mementic_frontend/src/Pages/Marketplace.jsx
@@ -324,17 +324,15 @@ const Marketplace = () => {
         throw new Error("Invalid meme identifier for listing");
       }
 
-      await backendService.listMemeForSale(BigInt(idText), options);
-      const normalizedMode =
-        (options.mode || options.auctionType) === "timed_auction"
-          ? "auction"
-          : (options.mode || "fixed");
+      const price = Number(options.price ?? options.listingPrice ?? options.amount);
+      if (!Number.isFinite(price) || price <= 0) {
+        throw new Error("Marketplace listings require a positive price");
+      }
+
+      await backendService.listMemeForSale(BigInt(idText), { price });
       toast({
         title: "Listing published",
-        description:
-          normalizedMode === "auction"
-            ? "Your meme NFT is now live in the auction arena."
-            : "Your meme NFT is now trading on the marketplace.",
+        description: "Your meme NFT is now trading on the marketplace.",
       });
 
       let refreshedSnapshot = null;
@@ -530,7 +528,7 @@ const Marketplace = () => {
                   Trade meme NFTs like it’s the opening bell
                 </h1>
                 <p className="text-lg text-muted-foreground sm:max-w-2xl">
-                  Monitor live drops, lock in fixed prices, or launch auctions with starting bids that feel like a trading floor.
+                  Monitor live drops, lock in fixed prices, and send bidding wars to the dedicated auction arena.
                   Every weekly winner can mint and list directly without leaving the exchange view.
                 </p>
                 <div className="flex flex-col gap-3 sm:flex-row">
@@ -1133,6 +1131,9 @@ const Marketplace = () => {
           onConfirm={handleListingSubmit}
           isProcessing={listingDialog.isSubmitting}
           error={listingDialog.error}
+          allowedModes={["fixed"]}
+          title="List on marketplace"
+          confirmLabel="Publish listing"
         />
     </PageShell>
   );

--- a/src/Mementic_frontend/src/Pages/Portfolio.jsx
+++ b/src/Mementic_frontend/src/Pages/Portfolio.jsx
@@ -121,6 +121,8 @@ const Portfolio = () => {
   const [listingModalOpen, setListingModalOpen] = useState(false);
   const [listingTarget, setListingTarget] = useState(null);
   const [listingLoading, setListingLoading] = useState(false);
+  const [listingContext, setListingContext] = useState("marketplace");
+  const [listingError, setListingError] = useState(null);
 
   const [usernameInput, setUsernameInput] = useState(sanitizedUsername);
   const [usernameError, setUsernameError] = useState("");
@@ -563,7 +565,10 @@ const Portfolio = () => {
       );
 
       setEntitlements(normalizedEntitlements);
-      setWinnerNotices(normalizedNotices);
+      const activeNotices = normalizedNotices.filter(
+        (notice) => notice.status === 'Active'
+      );
+      setWinnerNotices(activeNotices);
       setNfts(ui);
     } catch (e) {
       console.error("Error loading portfolio:", e);
@@ -633,50 +638,55 @@ const Portfolio = () => {
     }
   };
 
-  const openListingModal = (nft) => {
+  const openListingModal = (nft, context = "marketplace") => {
     setListingTarget(nft);
+    setListingContext(context);
+    setListingError(null);
     setListingModalOpen(true);
   };
 
   const closeListingModal = () => {
     setListingTarget(null);
     setListingModalOpen(false);
+    setListingError(null);
   };
 
   const handleListingConfirm = async (memeId, options = {}) => {
     try {
       setListingLoading(true);
+      setListingError(null);
       const idAsString = typeof memeId === "string" ? memeId : String(memeId);
       if (!/^\d+$/.test(idAsString)) {
         throw new Error("Invalid meme identifier for listing");
       }
 
-      const mode = (options.mode || options.auctionType) === "timed_auction" ? "auction" : (options.mode || "fixed");
-
-      if (mode === "auction") {
+      const context = listingContext;
+      if (context === "auction") {
         const startBid = Number(options.startingBid ?? options.price);
         if (!Number.isFinite(startBid) || startBid <= 0) {
           throw new Error("Auction listings require a positive starting bid");
         }
+        await backendService.startMemeAuction(BigInt(idAsString), { startingBid: startBid });
+        toast({
+          title: "Auction launched",
+          description: "Your NFT is now queued in the auction arena for live bidding.",
+        });
       } else {
-        const price = Number(options.price);
+        const price = Number(options.price ?? options.listingPrice ?? options.amount);
         if (!Number.isFinite(price) || price <= 0) {
-          throw new Error("Listing requires a positive price");
+          throw new Error("Marketplace listings require a positive price");
         }
+        await backendService.listMemeForSale(BigInt(idAsString), { price });
+        toast({
+          title: "Listing created successfully!",
+          description: "Your NFT is now visible on the marketplace.",
+        });
       }
-
-      await backendService.listMemeForSale(BigInt(idAsString), options);
-      toast({
-        title: "Listing created successfully!",
-        description:
-          mode === "auction"
-            ? "Your NFT is now live in the auction arena."
-            : "Your NFT is now visible on the marketplace.",
-      });
       closeListingModal();
       await fetchData();
     } catch (error) {
       console.error("Listing failed:", error);
+      setListingError(error?.message ?? "Failed to list NFT");
       toast({
         title: "Listing failed",
         description: error.message || "Could not list your NFT. Please try again.",
@@ -698,7 +708,7 @@ const Portfolio = () => {
       await backendService.removeMemeFromMarket(BigInt(idAsString));
       toast({
         title: "Listing removed",
-        description: "Your NFT has been delisted from the marketplace.",
+        description: "Your NFT listing has been removed.",
       });
       await fetchData();
     } catch (error) {
@@ -771,6 +781,10 @@ const Portfolio = () => {
       clearInterval(refreshInterval);
     };
   }, [isAuthenticated, loading, nfts]);
+
+  const listingModalAllowedModes = listingContext === "auction" ? ["auction"] : ["fixed"];
+  const listingModalTitle = listingContext === "auction" ? "Launch auction" : "List on marketplace";
+  const listingModalConfirmLabel = listingContext === "auction" ? "Start auction" : "Publish listing";
 
   if (authLoading) {
     return <LoadingState message="Connecting to your identity…" />;
@@ -1463,17 +1477,28 @@ const Portfolio = () => {
                           className="border-rose-300 text-rose-100 hover:bg-rose-500/20"
                           disabled={listingLoading}
                         >
-                          Delist from marketplace
+                          Remove listing
                         </Button>
                       ) : (
-                        <Button
-                          size="sm"
-                          onClick={() => openListingModal(nft)}
-                          className="bg-gradient-to-r from-amber-400 to-rose-400 text-black hover:opacity-90"
-                          disabled={listingLoading}
-                        >
-                          List on marketplace
-                        </Button>
+                        <>
+                          <Button
+                            size="sm"
+                            onClick={() => openListingModal(nft, "marketplace")}
+                            className="bg-gradient-to-r from-amber-400 to-rose-400 text-black hover:opacity-90"
+                            disabled={listingLoading}
+                          >
+                            List on marketplace
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => openListingModal(nft, "auction")}
+                            className="border border-secondary/40 bg-transparent text-secondary-foreground hover:bg-secondary/10"
+                            disabled={listingLoading}
+                          >
+                            Launch auction
+                          </Button>
+                        </>
                       )}
                       <Button
                         variant="outline"
@@ -1522,6 +1547,10 @@ const Portfolio = () => {
         nft={listingTarget}
         onConfirm={handleListingConfirm}
         isProcessing={listingLoading}
+        error={listingError}
+        allowedModes={listingModalAllowedModes}
+        title={listingModalTitle}
+        confirmLabel={listingModalConfirmLabel}
       />
     </div>
   );

--- a/src/Mementic_frontend/src/Pages/PreMarketplace.jsx
+++ b/src/Mementic_frontend/src/Pages/PreMarketplace.jsx
@@ -60,6 +60,9 @@ const PreMarketplace = () => {
     currentWeekStatus,
   } = useMarketplaceData(isAuthenticated, hasProfileName, page, sort, searchQuery);
 
+  const weekCompleted = Boolean(currentWeekStatus?.isCompleted);
+  const activeMemes = weekCompleted ? [] : memes;
+
   const {
     handleVote,
     checkMemeOwnership,
@@ -67,7 +70,11 @@ const PreMarketplace = () => {
 
   // Filter memes based on search query and creator
   const filteredMemes = useMemo(() => {
-    let base = memes;
+    if (weekCompleted) {
+      return [];
+    }
+
+    let base = activeMemes;
     if (selectedCreator !== "all") {
       base = base.filter((meme) => meme.creator === selectedCreator);
     }
@@ -79,39 +86,39 @@ const PreMarketplace = () => {
         (meme.caption?.toLowerCase() ?? "").includes(query) ||
         (meme.prompt?.toLowerCase() ?? "").includes(query)
     );
-  }, [memes, searchQuery, selectedCreator]);
+  }, [activeMemes, searchQuery, selectedCreator, weekCompleted]);
 
   // Computed stats
   const totalVotes = useMemo(
-    () => memes.reduce((acc, meme) => acc + (meme?.votes || 0), 0),
-    [memes]
+    () => activeMemes.reduce((acc, meme) => acc + (meme?.votes || 0), 0),
+    [activeMemes]
   );
 
   const totalViews = useMemo(
-    () => memes.reduce((acc, meme) => acc + (meme?.views || 0), 0),
-    [memes]
+    () => activeMemes.reduce((acc, meme) => acc + (meme?.views || 0), 0),
+    [activeMemes]
   );
 
   const listedCount = useMemo(
     () =>
-      memes.filter((meme) => {
+      activeMemes.filter((meme) => {
         const sale = meme?.sale_metadata ?? meme?.market_data;
         return sale?.is_listed;
       }).length,
-    [memes]
+    [activeMemes]
   );
 
   const uniqueCreators = useMemo(() => {
     const creators = new Set();
-    memes.forEach((meme) => {
+    activeMemes.forEach((meme) => {
       if (meme?.creator) creators.add(meme.creator);
     });
     return creators.size;
-  }, [memes]);
+  }, [activeMemes]);
 
   const creatorStats = useMemo(() => {
     const stats = new Map();
-    memes.forEach((meme) => {
+    activeMemes.forEach((meme) => {
       const creator = meme?.creator || "Anonymous";
       if (!stats.has(creator)) {
         stats.set(creator, { creator, count: 0, votes: 0 });
@@ -125,7 +132,7 @@ const PreMarketplace = () => {
         b.votes !== a.votes ? b.votes - a.votes : b.count - a.count
       )
       .slice(0, 6);
-  }, [memes]);
+  }, [activeMemes]);
 
   const topTrending = useMemo(
     () => topMemes.filter(Boolean).slice(0, 3),
@@ -150,7 +157,7 @@ const PreMarketplace = () => {
         value: "newest",
         label: "Newest",
         icon: "Sparkles",
-        meta: `${memes.length} drops`,
+        meta: `${activeMemes.length} drops`,
       },
       {
         value: "top",
@@ -165,7 +172,7 @@ const PreMarketplace = () => {
         meta: `${listedCount} live`,
       },
     ],
-    [listedCount, memes, totalViews, totalVotes]
+    [activeMemes.length, listedCount, totalViews, totalVotes]
   );
 
   const selectedCreatorLabel =
@@ -230,7 +237,6 @@ const PreMarketplace = () => {
     }
   };
 
-  const weekCompleted = Boolean(currentWeekStatus?.isCompleted);
   const canLoadMore = !weekCompleted && memes.length < total;
 
   if (authLoading) {
@@ -281,7 +287,7 @@ const PreMarketplace = () => {
           />
 
           <MarketplaceFeed
-            memes={memes}
+            memes={activeMemes}
             filteredMemes={filteredMemes}
             loadingList={loadingList}
             errorMsg={errorMsg}

--- a/src/Mementic_frontend/src/components/ListingModal.jsx
+++ b/src/Mementic_frontend/src/components/ListingModal.jsx
@@ -1,9 +1,40 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "./ui/Button";
 import { Input } from "./ui/Input";
 
-const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false, error = null }) => {
-  const [mode, setMode] = useState("fixed");
+const normalizeModes = (modes) => {
+  if (!Array.isArray(modes) || modes.length === 0) {
+    return ["fixed", "auction"];
+  }
+  const supported = new Set();
+  modes.forEach((mode) => {
+    if (!mode) return;
+    const trimmed = String(mode).toLowerCase();
+    if (trimmed === "fixed" || trimmed === "fixed_price") {
+      supported.add("fixed");
+    } else if (trimmed === "auction" || trimmed === "timed_auction") {
+      supported.add("auction");
+    }
+  });
+  if (supported.size === 0) {
+    supported.add("fixed");
+  }
+  return Array.from(supported);
+};
+
+const ListingModal = ({
+  isOpen,
+  onClose,
+  nft,
+  onConfirm,
+  isProcessing = false,
+  error = null,
+  allowedModes = ["fixed", "auction"],
+  title = "Launch NFT Listing",
+  confirmLabel = "List NFT",
+}) => {
+  const availableModes = useMemo(() => normalizeModes(allowedModes), [allowedModes]);
+  const [mode, setMode] = useState(availableModes[0] ?? "fixed");
   const [price, setPrice] = useState("");
   const [startingBid, setStartingBid] = useState("");
   const [duration, setDuration] = useState("7"); // days
@@ -12,14 +43,20 @@ const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false, e
 
   useEffect(() => {
     if (isOpen) {
-      setMode("fixed");
+      setMode(availableModes[0] ?? "fixed");
       setPrice("");
       setStartingBid("");
       setDuration("7");
       setRoyalties("5");
       setFormError(null);
     }
-  }, [isOpen]);
+  }, [isOpen, availableModes]);
+
+  useEffect(() => {
+    if (!availableModes.includes(mode)) {
+      setMode(availableModes[0] ?? "fixed");
+    }
+  }, [availableModes, mode]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -51,12 +88,20 @@ const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false, e
 
   if (!isOpen || !nft) return null;
 
+  const allowFixed = availableModes.includes("fixed");
+  const allowAuction = availableModes.includes("auction");
+  const showModeToggle = allowFixed && allowAuction;
+  const gridColumns = showModeToggle ? "grid-cols-2" : "grid-cols-1";
+
+  const resolvedTitle = title || (showModeToggle ? "Launch NFT Listing" : allowAuction ? "Launch auction" : "List on marketplace");
+  const resolvedConfirmLabel = confirmLabel || (allowAuction && !allowFixed ? "Start auction" : "List NFT");
+
   return (
     <div className={`fixed inset-0 z-50 flex items-center justify-center ${isOpen ? "" : "hidden"}`}>
       <div className="fixed inset-0 bg-black/50" onClick={onClose} />
       <div className="relative bg-background rounded-lg shadow-lg max-w-md w-full mx-4 max-h-[90vh] overflow-y-auto">
         <div className="p-6">
-          <h2 className="text-lg font-semibold mb-4">Launch NFT Listing</h2>
+          <h2 className="text-lg font-semibold mb-4">{resolvedTitle}</h2>
 
           <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
@@ -81,41 +126,69 @@ const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false, e
           </div>
 
           <div className="space-y-4">
-            <div>
-              <label className="text-sm font-medium">Listing Mode</label>
-              <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
-                <button
-                  type="button"
-                  onClick={() => setMode("fixed")}
-                  disabled={isProcessing}
-                  className={`rounded-md border px-3 py-2 text-left ${
-                    mode === "fixed"
-                      ? "border-primary bg-primary/10 text-primary"
-                      : "border-input hover:border-primary/40"
-                  }`}
-                >
-                  <span className="block font-semibold">Fixed price</span>
-                  <span className="block text-xs text-muted-foreground">
-                    Set a buy-now price for collectors.
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setMode("auction")}
-                  disabled={isProcessing}
-                  className={`rounded-md border px-3 py-2 text-left ${
-                    mode === "auction"
-                      ? "border-primary bg-primary/10 text-primary"
-                      : "border-input hover:border-primary/40"
-                  }`}
-                >
-                  <span className="block font-semibold">Auction</span>
-                  <span className="block text-xs text-muted-foreground">
-                    Kick off live bidding with a floor price.
-                  </span>
-                </button>
+            {showModeToggle ? (
+              <div>
+                <label className="text-sm font-medium">Listing Mode</label>
+                <div className={`mt-2 grid ${gridColumns} gap-2 text-sm`}>
+                  {allowFixed && (
+                    <button
+                      type="button"
+                      onClick={() => setMode("fixed")}
+                      disabled={isProcessing}
+                      className={`rounded-md border px-3 py-2 text-left ${
+                        mode === "fixed"
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-input hover:border-primary/40"
+                      }`}
+                    >
+                      <span className="block font-semibold">Fixed price</span>
+                      <span className="block text-xs text-muted-foreground">
+                        Set a buy-now price for collectors.
+                      </span>
+                    </button>
+                  )}
+                  {allowAuction && (
+                    <button
+                      type="button"
+                      onClick={() => setMode("auction")}
+                      disabled={isProcessing}
+                      className={`rounded-md border px-3 py-2 text-left ${
+                        mode === "auction"
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-input hover:border-primary/40"
+                      }`}
+                    >
+                      <span className="block font-semibold">Auction</span>
+                      <span className="block text-xs text-muted-foreground">
+                        Kick off live bidding with a floor price.
+                      </span>
+                    </button>
+                  )}
+                </div>
               </div>
-            </div>
+            ) : (
+              <div>
+                <label className="text-sm font-medium">Listing Mode</label>
+                <div className={`mt-2 grid ${gridColumns} gap-2 text-sm`}>
+                  {allowFixed && (
+                    <div className="rounded-md border border-primary bg-primary/10 p-3 text-left text-primary">
+                      <span className="block text-sm font-semibold">Fixed price</span>
+                      <span className="block text-xs text-primary/80">
+                        Marketplace listings close instantly with a buy-now price.
+                      </span>
+                    </div>
+                  )}
+                  {allowAuction && (
+                    <div className="rounded-md border border-primary bg-primary/10 p-3 text-left text-primary">
+                      <span className="block text-sm font-semibold">Auction</span>
+                      <span className="block text-xs text-primary/80">
+                        Bids will be managed from the auction arena.
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
 
             <div>
               <label className="text-sm font-medium">
@@ -138,7 +211,7 @@ const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false, e
               />
             </div>
 
-            {mode === "auction" && (
+            {mode === "auction" && allowAuction && (
               <div>
                 <label className="text-sm font-medium">Duration (days)</label>
                 <Input
@@ -186,7 +259,7 @@ const ListingModal = ({ isOpen, onClose, nft, onConfirm, isProcessing = false, e
               className="flex-1 bg-gradient-to-r from-green-500 to-emerald-500"
               disabled={isProcessing}
             >
-              {isProcessing ? "Listing…" : "List NFT"}
+              {isProcessing ? "Listing…" : resolvedConfirmLabel}
             </Button>
           </div>
           </form>

--- a/src/Mementic_frontend/src/hooks/useMarketplaceData.js
+++ b/src/Mementic_frontend/src/hooks/useMarketplaceData.js
@@ -187,6 +187,13 @@ export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, 
       return;
     }
 
+    if (currentWeekStatus?.isCompleted) {
+      setMemes([]);
+      setTotal(0);
+      setLoadingList(false);
+      return;
+    }
+
     setLoadingList(true);
     setErrorMsg("");
     try {

--- a/src/Mementic_frontend/src/services/backendService.js
+++ b/src/Mementic_frontend/src/services/backendService.js
@@ -691,7 +691,6 @@ class BackendService {
     if (!this.isAuthenticated) {
       throw new Error("Authentication required: Please login to list memes");
     }
-    const mode = (options.mode || options.type || "fixed_price").toLowerCase();
 
     const ensurePositive = (value, label) => {
       const num = Number(value);
@@ -701,22 +700,45 @@ class BackendService {
       return num;
     };
 
-    let strategy;
-    if (mode === "auction" || mode === "timed_auction") {
-      const start = ensurePositive(
-        options.startingBid ?? options.startPrice ?? options.price,
-        "Starting bid"
+    const explicitMode = (options.mode || options.type || options.listingType || "").toLowerCase();
+    if (explicitMode.includes("auction")) {
+      throw new Error(
+        "Marketplace listings only support fixed prices. Launch auctions from the auction arena."
       );
-      const startE8s = BigInt(Math.round(start * 100000000));
-      strategy = { Auction: { start_price_e8s: startE8s } };
-    } else {
-      const price = ensurePositive(options.price, "Listing price");
-      const priceE8s = BigInt(Math.round(price * 100000000));
-      strategy = { FixedPrice: { price_e8s: priceE8s } };
     }
+
+    const priceCandidate =
+      options.price ?? options.listingPrice ?? options.amount ?? options.startingBid;
+    const price = ensurePositive(priceCandidate, "Listing price");
+    const priceE8s = BigInt(Math.round(price * 100000000));
+    const strategy = { FixedPrice: { price_e8s: priceE8s } };
 
     const result = await this._safeCall('list_meme_for_sale', memeId, strategy);
     return this._unwrapResult(result, "list_meme_for_sale failed");
+  }
+
+  async startMemeAuction(memeId, options = {}) {
+    if (!this.isAuthenticated) {
+      throw new Error("Authentication required: Please login to launch auctions");
+    }
+
+    const ensurePositive = (value, label) => {
+      const num = Number(value);
+      if (!Number.isFinite(num) || num <= 0) {
+        throw new Error(`${label} must be greater than zero`);
+      }
+      return num;
+    };
+
+    const startingBid = ensurePositive(
+      options.startingBid ?? options.startPrice ?? options.price,
+      "Starting bid"
+    );
+    const startE8s = BigInt(Math.round(startingBid * 100000000));
+    const strategy = { Auction: { start_price_e8s: startE8s } };
+
+    const result = await this._safeCall('list_meme_for_sale', memeId, strategy);
+    return this._unwrapResult(result, "start_meme_auction failed");
   }
 
   /**


### PR DESCRIPTION
## Summary
- restrict marketplace listing submission to fixed-price flow and update the hero copy to push bidding to the auction arena
- expand the reusable listing modal so callers can lock it to fixed-price or auction-only contexts
- add a dedicated auction launch path from the portfolio backed by a new backend helper that wraps the auction listing strategy

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f25924dda8832b80dd52f13889b0d0