### PR TITLE
Ensure weekly rollover timer performs immediate catch-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,27 @@ If you are hosting frontend code somewhere without using DFX, you may need to ma
 - Write your own `createActor` constructor
 ![Tech Stack](./images/9.jpg)
 
+## Weekly Rollover Operations
+
+### Week boundary logic
+Mementic groups memes into calendar weeks using UTC boundaries. The backend exposes helper functions that compute a `week_id = floor(timestamp_secs / 604800)` and stores the value with every meme. An optional signed offset (default `0`) can be applied to support alternative boundaries such as IST; the offset is persisted in stable memory and can be updated with the `admin_set_week_offset` canister method.
+
+### Automatic timers
+During `init` and `post_upgrade` the backend arms an hourly `ic_cdk_timers::set_timer_interval` callback. The timer runs an immediate catch-up check and then continues to invoke the rollover logic every hour which:
+
+1. Detects when the calendar week has changed.
+2. Finalizes the previous week’s memes (marks them `Finalized`, stamps `finalized_at`, and sets `week_ended = true`).
+3. Snapshots the top votes into a stable `FINALIZED_LEADERBOARDS` map and resets live vote tallies.
+4. Advances the active week id so that the pre-marketplace only exposes fresh memes.
+
+Because the operation is idempotent it is safe to leave the timer running even if no new memes were posted.
+
+### Manual rollover
+For operational recovery or demo purposes you can force a rollover with `dfx canister call Mementic_backend admin_rollover_now`. The call performs the same steps as the timer based workflow and is guarded only by the canister allowlist.
+
+### Legacy meme migration
+Existing meme records created before this change remain in stable memory. When a new meme is published through `publish_meme` it is automatically registered with the weekly index so the new queries return the same objects. For older deployments you may run a one-off migration that reads previous entries, computes the week from `created_at`, and inserts them via the same registration routine—this keeps `NEXT_MEME_ID` in sync and ensures portfolios can reference historical weeks.
+
 ## Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.

--- a/src/Mementic_backend/Mementic_backend.did
+++ b/src/Mementic_backend/Mementic_backend.did
@@ -90,7 +90,7 @@ type PythonMetadata = record {
 type Result = variant { Ok : text; Err : text };
 type Result_1 = variant { Ok : nat32; Err : text };
 type Result_2 = variant { Ok; Err : text };
-type Result_3 = variant { Ok : vec TopEntry; Err : text };
+type Result_3 = variant { Ok : vec LegacyTopEntry; Err : text };
 type Result_4 = variant { Ok : vec nat; Err : text };
 type Result_5 = variant { Ok : PublicStoredMeme; Err : text };
 type Result_6 = variant { Ok : VoteResponse; Err : text };
@@ -125,13 +125,20 @@ type TokenSaleMetadata = record {
   auction_highest_bid : opt nat64;
   listed_at : opt nat64;
 };
-type TopEntry = record {
+type LegacyTopEntry = record {
   upvotes : nat32;
   last_vote_time : nat64;
   meme_id : nat64;
   score : float64;
   downvotes : nat32;
 };
+type MemeCard = record {
+  id : nat64;
+  caption : text;
+  image_cid : text;
+  creator : principal;
+};
+type MemeStatus = variant { InVoting; Finalized };
 type TopLikedLeaderboard = record {
   total_ranked : nat32;
   top_memes : vec LeaderboardEntry;
@@ -152,11 +159,17 @@ type VoteResponse = record {
   user_previous_vote : opt VoteType;
 };
 type VoteType = variant { Downvote; Upvote };
-type WeeklyLeaderboard = record {
+type LegacyWeeklyLeaderboard = record {
   week_id : nat64;
   period : WeeklyPeriod;
   top_memes : vec LeaderboardEntry;
   is_active : bool;
+};
+type TopEntry = record { meme_id : nat64; votes : nat64; rank : nat32 };
+type WeeklyLeaderboard = record {
+  week_id : nat64;
+  finalized_at : nat64;
+  top : vec TopEntry;
 };
 type WeeklyPeriod = record {
   meme_count : nat32;
@@ -205,10 +218,13 @@ service : (opt InitArgs) -> {
   get_all_minted_tokens : () -> (vec TokenRecord) query;
   // Get all approved feedback for public display
   get_approved_feedback : (opt nat32) -> (vec Feedback) query;
+  create_meme : (text, text) -> (nat64);
   // Completed weeks
   get_completed_weeks : () -> (vec WeeklyPeriod) query;
-  // Current weekly leaderboard (active week). Limit max 50.
-  get_current_leaderboard : (opt nat32) -> (WeeklyLeaderboard) query;
+  // Current weekly leaderboard (active week) with pagination.
+  get_current_leaderboard : (nat32, nat32) -> (vec TopEntry) query;
+  // Legacy current leaderboard snapshot.
+  get_current_leaderboard_legacy : (opt nat32) -> (LegacyWeeklyLeaderboard) query;
   // Status for current week
   get_current_week_status : () -> (nat64, nat64, nat64, bool) query;
   get_entitlements_for_meme : (nat64) -> (vec MintEntitlement) query;
@@ -217,6 +233,7 @@ service : (opt InitArgs) -> {
   // Get only memes that are listed for sale on the marketplace
   get_marketplace_memes : () -> (vec PublicStoredMeme) query;
   get_meme : (nat64) -> (opt PublicStoredMeme) query;
+  get_leaderboard_by_week : (nat64) -> (opt WeeklyLeaderboard) query;
   // Get per-meme votes
   get_meme_votes : (nat64) -> (opt MemeVotes) query;
   get_my_mint_entitlements : () -> (vec MintEntitlement) query;
@@ -244,7 +261,12 @@ service : (opt InitArgs) -> {
   // Did caller vote on meme?
   get_user_vote : (nat64) -> (opt VoteRecord) query;
   // Leaderboard for any week id. Returns None if week not found.
-  get_week_leaderboard : (nat64, opt nat32) -> (opt WeeklyLeaderboard) query;
+  get_week_leaderboard : (nat64, opt nat32) -> (opt LegacyWeeklyLeaderboard) query;
+  get_active_week : () -> (nat64) query;
+  get_week_offset : () -> (int64) query;
+  list_finalized_weeks : (nat32, nat32) -> (vec nat64) query;
+  list_memes_by_flag : (bool, nat32, nat32) -> (vec MemeCard) query;
+  list_premarket_memes : (nat32, nat32) -> (vec MemeCard) query;
   health : () -> (text) query;
   icrc7_name : () -> (text) query;
   icrc7_owner_of : (vec nat) -> (vec opt principal) query;
@@ -261,6 +283,8 @@ service : (opt InitArgs) -> {
   mint_to : (nat64, MintingMode) -> (Result_4);
   // Store a generated meme into marketplace (associated to caller)
   publish_meme : (MemeData) -> (Result_5);
+  admin_rollover_now : () -> (opt nat64);
+  admin_set_week_offset : (int64) -> ();
   // Record a sale (called internally or by marketplace canister)
   record_meme_sale : (nat64, nat64) -> (Result_2);
   // Remove all memes from the marketplace (admin function)
@@ -279,5 +303,6 @@ service : (opt InitArgs) -> {
   // Cast or change a vote on a meme in the **current active week**.
   // Rejects if meme is not from current week or if the week is completed/expired.
   vote_meme : (nat64, VoteType) -> (Result_6);
+  vote : (nat64, bool) -> (Result_2);
   whoami : () -> (principal) query;
 }

--- a/src/Mementic_backend/src/api_create.rs
+++ b/src/Mementic_backend/src/api_create.rs
@@ -1,0 +1,55 @@
+use crate::index::append_meme_to_week;
+use crate::model::{Meme, MemeId, MemeStatus};
+use crate::rollover;
+use crate::state::{ensure_next_meme_id_at_least, get_active_week_id, set_active_week_id, MEMES};
+use crate::time::{compute_week_id, current_week_id, now_secs};
+use candid::Principal;
+use ic_cdk::caller;
+
+pub fn create_meme(caption: String, image_cid: String) -> MemeId {
+    // Ensure rollover if the calendar week has advanced.
+    rollover::maybe_perform_rollover(crate::leaderboard::DEFAULT_TOP_N);
+
+    let creator = caller();
+    let created_at = now_secs();
+    let week_id = current_week_id();
+
+    let meme_id = crate::http_outcall::reserve_meme_id();
+    register_meme_with_id(meme_id, creator, caption, image_cid, created_at);
+
+    meme_id
+}
+
+pub fn register_meme_with_id(
+    meme_id: MemeId,
+    creator: Principal,
+    caption: String,
+    image_cid: String,
+    created_at_secs: u64,
+) {
+    let week_id = compute_week_id(created_at_secs);
+    let meme = Meme {
+        id: meme_id,
+        creator,
+        image_cid,
+        caption,
+        created_at: created_at_secs,
+        week_id,
+        status: MemeStatus::InVoting,
+        week_ended: false,
+        finalized_at: None,
+    };
+
+    MEMES.with(|memes| {
+        memes.borrow_mut().insert(meme_id, meme);
+    });
+
+    append_meme_to_week(week_id, meme_id);
+
+    ensure_next_meme_id_at_least(meme_id.saturating_add(1));
+
+    let current_active = get_active_week_id();
+    if current_active == 0 || week_id >= current_active {
+        set_active_week_id(week_id);
+    }
+}

--- a/src/Mementic_backend/src/api_query.rs
+++ b/src/Mementic_backend/src/api_query.rs
@@ -1,0 +1,78 @@
+use crate::index;
+use crate::leaderboard;
+use crate::model::{MemeCard, MemeStatus, TopEntry, WeekId, WeeklyLeaderboard};
+use crate::state::{get_active_week_id, MEMES};
+
+fn meme_to_card(meme: &crate::model::Meme) -> MemeCard {
+    MemeCard {
+        id: meme.id,
+        caption: meme.caption.clone(),
+        image_cid: meme.image_cid.clone(),
+        creator: meme.creator,
+    }
+}
+
+pub fn list_premarket_memes(offset: u32, limit: u32) -> Vec<MemeCard> {
+    let week_id = get_active_week_id();
+    let ids = index::week_meme_ids(week_id);
+    let cards: Vec<MemeCard> = ids
+        .into_iter()
+        .filter_map(|id| {
+            MEMES
+                .with(|memes| memes.borrow().get(&id))
+                .and_then(|meme| {
+                    if meme.status == MemeStatus::InVoting
+                        && !meme.week_ended
+                        && meme.week_id == week_id
+                    {
+                        Some(meme_to_card(&meme))
+                    } else {
+                        None
+                    }
+                })
+        })
+        .collect();
+
+    let start = offset as usize;
+    let end = (start + limit as usize).min(cards.len());
+    if start >= cards.len() {
+        return Vec::new();
+    }
+    cards[start..end].to_vec()
+}
+
+pub fn get_current_leaderboard(offset: u32, limit: u32) -> Vec<TopEntry> {
+    leaderboard::current_leaderboard(offset, limit)
+}
+
+pub fn get_leaderboard_by_week(week_id: WeekId) -> Option<WeeklyLeaderboard> {
+    leaderboard::get_weekly_leaderboard(week_id)
+}
+
+pub fn list_finalized_weeks(offset: u32, limit: u32) -> Vec<WeekId> {
+    leaderboard::list_finalized_weeks(offset, limit)
+}
+
+pub fn list_memes_by_flag(week_ended: bool, offset: u32, limit: u32) -> Vec<MemeCard> {
+    let items: Vec<MemeCard> = MEMES.with(|memes| {
+        memes
+            .borrow()
+            .iter()
+            .filter_map(|entry| {
+                let meme = entry.value();
+                if meme.week_ended == week_ended {
+                    Some(meme_to_card(&meme))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    });
+
+    let start = offset as usize;
+    let end = (start + limit as usize).min(items.len());
+    if start >= items.len() {
+        return Vec::new();
+    }
+    items[start..end].to_vec()
+}

--- a/src/Mementic_backend/src/api_vote.rs
+++ b/src/Mementic_backend/src/api_vote.rs
@@ -1,0 +1,30 @@
+use crate::leaderboard::apply_vote;
+use crate::model::{MemeId, MemeStatus};
+use crate::rollover;
+use crate::state::{get_active_week_id, MEMES};
+use candid::Principal;
+use ic_cdk::caller;
+
+pub fn vote(meme_id: MemeId, up: bool) -> Result<(), String> {
+    rollover::maybe_perform_rollover(crate::leaderboard::DEFAULT_TOP_N);
+
+    let caller = caller();
+    if caller == Principal::anonymous() {
+        return Err("Anonymous votes are not allowed".into());
+    }
+
+    let meme = MEMES
+        .with(|memes| memes.borrow().get(&meme_id))
+        .ok_or("Meme not found")?;
+
+    if meme.week_id != get_active_week_id() {
+        return Err("Voting is only allowed on the active week".into());
+    }
+
+    if meme.status != MemeStatus::InVoting || meme.week_ended {
+        return Err("Voting is closed for this meme".into());
+    }
+
+    apply_vote(meme_id, up);
+    Ok(())
+}

--- a/src/Mementic_backend/src/feedback.rs
+++ b/src/Mementic_backend/src/feedback.rs
@@ -1,7 +1,7 @@
 // src/feedback.rs
-use candid::{CandidType, Principal, Decode, Encode};
-use ic_cdk::{caller, api::time};
-use ic_cdk_macros::{query, update, init, post_upgrade};
+use candid::{CandidType, Decode, Encode, Principal};
+use ic_cdk::{api::time, caller};
+use ic_cdk_macros::{init, post_upgrade, query, update};
 use ic_stable_structures::{
     memory_manager::{MemoryId, MemoryManager, VirtualMemory},
     storable::{Bound, Storable},
@@ -63,7 +63,6 @@ pub fn init_feedback_data() {
     // Initialize without sample data - only real user feedback will be shown
 }
 
-
 // ---------- Main feedback functions ----------
 
 /// Submit feedback from a user
@@ -112,7 +111,10 @@ pub fn submit_feedback(
         f.borrow_mut().insert(feedback_id, feedback);
     });
 
-    Ok(format!("Feedback submitted successfully with ID: {}", feedback_id))
+    Ok(format!(
+        "Feedback submitted successfully with ID: {}",
+        feedback_id
+    ))
 }
 
 /// Get all approved feedback for public display
@@ -157,10 +159,8 @@ pub fn get_all_feedback() -> Vec<Feedback> {
 
     FEEDBACK.with(|f| {
         let feedback_map = f.borrow();
-        let mut all_feedback: Vec<Feedback> = feedback_map
-            .iter()
-            .map(|entry| entry.value())
-            .collect();
+        let mut all_feedback: Vec<Feedback> =
+            feedback_map.iter().map(|entry| entry.value()).collect();
 
         // Sort by timestamp descending
         all_feedback.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));

--- a/src/Mementic_backend/src/http_outcall.rs
+++ b/src/Mementic_backend/src/http_outcall.rs
@@ -17,6 +17,7 @@ use ic_stable_structures::{
 use ic_cdk::api::call::call;
 use ic_cdk::api::call::call_with_payment;
 
+use crate::api_create::register_meme_with_id;
 use crate::nft_module::{ListingType, TokenSaleMetadata};
 use ic_stable_structures::storable::Bound;
 use serde::{Deserialize, Serialize};
@@ -576,6 +577,10 @@ fn next_meme_id() -> u64 {
     })
 }
 
+pub fn reserve_meme_id() -> u64 {
+    next_meme_id()
+}
+
 /// Check if a meme has been minted as an NFT
 #[query]
 pub fn is_meme_minted(meme_id: u64) -> bool {
@@ -889,10 +894,11 @@ pub fn publish_meme(meme: MemeData) -> Result<PublicStoredMeme, String> {
     }
 
     ic_cdk::println!("Publish meme - Authenticated user: {}", user.to_text());
+    crate::rollover::maybe_perform_rollover(crate::leaderboard::DEFAULT_TOP_N);
     let now = time();
 
     // Allocate id
-    let id = next_meme_id();
+    let id = reserve_meme_id();
 
     // Create stored record
     let stored = StoredMeme {
@@ -922,6 +928,11 @@ pub fn publish_meme(meme: MemeData) -> Result<PublicStoredMeme, String> {
     UNIQUE_USERS.with(|uu| {
         uu.borrow_mut().insert(StorablePrincipal::from(user), true);
     });
+
+    let caption = stored.meme_data.caption.clone().unwrap_or_else(String::new);
+    let image_cid = stored.meme_data.image_url.clone();
+    let created_secs = now / 1_000_000_000;
+    register_meme_with_id(id, user, caption, image_cid, created_secs);
 
     Ok(stored.into())
 }

--- a/src/Mementic_backend/src/index.rs
+++ b/src/Mementic_backend/src/index.rs
@@ -1,0 +1,17 @@
+use crate::model::{MemeId, WeekId};
+use crate::state::{MemeIdList, MEMES_BY_WEEK};
+
+pub fn append_meme_to_week(week_id: WeekId, meme_id: MemeId) {
+    MEMES_BY_WEEK.with(|map| {
+        let mut map = map.borrow_mut();
+        let mut list = map.get(&week_id).map(|l| l.0).unwrap_or_default();
+        if !list.contains(&meme_id) {
+            list.push(meme_id);
+            map.insert(week_id, MemeIdList(list));
+        }
+    });
+}
+
+pub fn week_meme_ids(week_id: WeekId) -> Vec<MemeId> {
+    MEMES_BY_WEEK.with(|map| map.borrow().get(&week_id).map(|l| l.0).unwrap_or_default())
+}

--- a/src/Mementic_backend/src/leaderboard.rs
+++ b/src/Mementic_backend/src/leaderboard.rs
@@ -1,0 +1,132 @@
+use crate::index::week_meme_ids;
+use crate::model::{MemeId, Timestamp, TopEntry, WeekId, WeeklyLeaderboard};
+use crate::state::get_active_week_id;
+use crate::state::{FINALIZED_LEADERBOARDS, LIVE_VOTES};
+
+pub const DEFAULT_TOP_N: usize = 50;
+
+fn sort_entries(entries: &mut Vec<(MemeId, u64)>) {
+    entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+}
+
+pub fn apply_vote(meme_id: MemeId, up: bool) -> u64 {
+    LIVE_VOTES.with(|votes| {
+        let mut votes = votes.borrow_mut();
+        let current = votes.get(&meme_id).unwrap_or(0);
+        let updated = if up {
+            current.saturating_add(1)
+        } else {
+            current.saturating_sub(1)
+        };
+        if updated == 0 {
+            votes.remove(&meme_id);
+        } else {
+            votes.insert(meme_id, updated);
+        }
+        updated
+    })
+}
+
+pub fn set_vote_count(meme_id: MemeId, value: u64) {
+    LIVE_VOTES.with(|votes| {
+        let mut votes = votes.borrow_mut();
+        if value == 0 {
+            votes.remove(&meme_id);
+        } else {
+            votes.insert(meme_id, value);
+        }
+    });
+}
+
+pub fn get_vote_count(meme_id: MemeId) -> u64 {
+    LIVE_VOTES.with(|votes| votes.borrow().get(&meme_id).unwrap_or(0))
+}
+
+pub fn clear_live_votes() {
+    LIVE_VOTES.with(|votes| {
+        let mut votes = votes.borrow_mut();
+        let keys: Vec<MemeId> = votes.iter().map(|entry| *entry.key()).collect();
+        for key in keys {
+            votes.remove(&key);
+        }
+    });
+}
+
+fn live_vote_entries_for_week(week_id: WeekId) -> Vec<(MemeId, u64)> {
+    let mut entries: Vec<(MemeId, u64)> = week_meme_ids(week_id)
+        .into_iter()
+        .map(|meme_id| (meme_id, get_vote_count(meme_id)))
+        .collect();
+
+    sort_entries(&mut entries);
+    entries
+}
+
+pub fn current_leaderboard(offset: u32, limit: u32) -> Vec<TopEntry> {
+    let week_id = get_active_week_id();
+    let mut entries = live_vote_entries_for_week(week_id);
+    let start = offset as usize;
+    let end = (start + limit as usize).min(entries.len());
+    if start >= entries.len() {
+        return Vec::new();
+    }
+    entries[start..end]
+        .iter()
+        .enumerate()
+        .map(|(idx, (meme_id, votes))| TopEntry {
+            meme_id: *meme_id,
+            votes: *votes,
+            rank: (start + idx + 1) as u32,
+        })
+        .collect()
+}
+
+pub fn snapshot_weekly_leaderboard(
+    week_id: WeekId,
+    finalized_at: Timestamp,
+    top_n: usize,
+) -> WeeklyLeaderboard {
+    let mut entries = live_vote_entries_for_week(week_id);
+    entries.truncate(top_n);
+
+    let top = entries
+        .iter()
+        .enumerate()
+        .map(|(idx, (meme_id, votes))| TopEntry {
+            meme_id: *meme_id,
+            votes: *votes,
+            rank: (idx + 1) as u32,
+        })
+        .collect();
+
+    WeeklyLeaderboard {
+        week_id,
+        finalized_at,
+        top,
+    }
+}
+
+pub fn store_weekly_leaderboard(board: WeeklyLeaderboard) {
+    FINALIZED_LEADERBOARDS.with(|map| {
+        map.borrow_mut().insert(board.week_id, board);
+    });
+}
+
+pub fn get_weekly_leaderboard(week_id: WeekId) -> Option<WeeklyLeaderboard> {
+    FINALIZED_LEADERBOARDS.with(|map| map.borrow().get(&week_id))
+}
+
+pub fn list_finalized_weeks(offset: u32, limit: u32) -> Vec<WeekId> {
+    FINALIZED_LEADERBOARDS.with(|map| {
+        let map = map.borrow();
+        let mut weeks: Vec<WeekId> = map.iter().map(|entry| *entry.key()).collect();
+        weeks.sort_unstable();
+        weeks.reverse();
+        let start = offset as usize;
+        let end = (start + limit as usize).min(weeks.len());
+        if start >= weeks.len() {
+            return Vec::new();
+        }
+        weeks[start..end].to_vec()
+    })
+}

--- a/src/Mementic_backend/src/lib.rs
+++ b/src/Mementic_backend/src/lib.rs
@@ -1,7 +1,16 @@
+mod api_create;
+mod api_query;
+mod api_vote;
 mod entitlements;
 mod feedback;
 mod http_outcall;
+mod index;
+mod leaderboard;
+mod model;
 mod nft_module;
+mod rollover;
+mod state;
+mod time;
 mod user_profiles;
 mod voting;
 
@@ -9,8 +18,10 @@ use crate::nft_module::InitArgs;
 use candid::{CandidType, Decode, Encode, Nat, Principal};
 use ic_cdk::api::management_canister::http_request::HttpResponse;
 use ic_cdk::api::management_canister::http_request::TransformArgs;
-use ic_cdk_macros::{query, update};
+use ic_cdk_macros::{post_upgrade, query, update};
 use serde::{Deserialize, Serialize};
+
+pub use model::{MemeCard, MemeStatus, TopEntry, WeeklyLeaderboard};
 
 pub use http_outcall::{
     check_remaining_calls,
@@ -39,10 +50,10 @@ pub use http_outcall::{
 };
 
 pub use voting::{
-    finalize_finished_weeks, finalize_week, get_completed_weeks, get_current_leaderboard,
-    get_current_week_status, get_meme_votes, get_top3_for_week, get_top_liked_memes, get_user_vote,
-    get_voting_stats, get_week_leaderboard, remove_vote, vote_meme, LeaderboardEntry, MemeVotes,
-    TopEntry, TopLikedLeaderboard, VoteRecord, VoteResponse, VoteType, WeeklyLeaderboard,
+    finalize_finished_weeks, finalize_week, get_completed_weeks, get_current_week_status,
+    get_meme_votes, get_top3_for_week, get_top_liked_memes, get_user_vote, get_voting_stats,
+    get_week_leaderboard, remove_vote, vote_meme, LeaderboardEntry, LegacyTopEntry,
+    LegacyWeeklyLeaderboard, MemeVotes, TopLikedLeaderboard, VoteRecord, VoteResponse, VoteType,
     WeeklyPeriod,
 };
 
@@ -88,6 +99,67 @@ pub use user_profiles::{
 #[query]
 pub fn whoami() -> Principal {
     ic_cdk::caller()
+}
+
+#[update]
+pub fn create_meme(caption: String, image_cid: String) -> u64 {
+    api_create::create_meme(caption, image_cid)
+}
+
+#[update]
+pub fn vote(meme_id: u64, up: bool) -> Result<(), String> {
+    api_vote::vote(meme_id, up)
+}
+
+#[query]
+pub fn list_premarket_memes(offset: u32, limit: u32) -> Vec<MemeCard> {
+    api_query::list_premarket_memes(offset, limit)
+}
+
+#[query]
+pub fn get_current_leaderboard(offset: u32, limit: u32) -> Vec<TopEntry> {
+    api_query::get_current_leaderboard(offset, limit)
+}
+
+#[query]
+pub fn get_leaderboard_by_week(week_id: u64) -> Option<WeeklyLeaderboard> {
+    api_query::get_leaderboard_by_week(week_id)
+}
+
+#[query]
+pub fn list_finalized_weeks(offset: u32, limit: u32) -> Vec<u64> {
+    api_query::list_finalized_weeks(offset, limit)
+}
+
+#[query]
+pub fn list_memes_by_flag(week_ended: bool, offset: u32, limit: u32) -> Vec<MemeCard> {
+    api_query::list_memes_by_flag(week_ended, offset, limit)
+}
+
+#[update]
+pub fn admin_rollover_now() -> Option<u64> {
+    rollover::admin_rollover_now()
+}
+
+#[update]
+pub fn admin_set_week_offset(offset_secs: i64) {
+    state::set_week_offset(offset_secs);
+}
+
+#[query]
+pub fn get_active_week() -> u64 {
+    state::get_active_week_id()
+}
+
+#[query]
+pub fn get_week_offset() -> i64 {
+    state::get_week_offset()
+}
+
+#[post_upgrade]
+fn post_upgrade() {
+    rollover::ensure_active_week_initialized();
+    rollover::start_rollover_timer();
 }
 
 ic_cdk::export_candid!();

--- a/src/Mementic_backend/src/model.rs
+++ b/src/Mementic_backend/src/model.rs
@@ -1,0 +1,56 @@
+use candid::{CandidType, Principal};
+use serde::{Deserialize, Serialize};
+
+pub type MemeId = u64;
+pub type WeekId = u64;
+pub type Timestamp = u64;
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize, PartialEq, Eq)]
+pub enum MemeStatus {
+    InVoting,
+    Finalized,
+}
+
+impl Default for MemeStatus {
+    fn default() -> Self {
+        MemeStatus::InVoting
+    }
+}
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct Meme {
+    pub id: MemeId,
+    pub creator: Principal,
+    pub image_cid: String,
+    pub caption: String,
+    pub created_at: Timestamp,
+    pub week_id: WeekId,
+    #[serde(default)]
+    pub status: MemeStatus,
+    #[serde(default)]
+    pub week_ended: bool,
+    #[serde(default)]
+    pub finalized_at: Option<Timestamp>,
+}
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct TopEntry {
+    pub meme_id: MemeId,
+    pub votes: u64,
+    pub rank: u32,
+}
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct WeeklyLeaderboard {
+    pub week_id: WeekId,
+    pub finalized_at: Timestamp,
+    pub top: Vec<TopEntry>,
+}
+
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize)]
+pub struct MemeCard {
+    pub id: MemeId,
+    pub caption: String,
+    pub image_cid: String,
+    pub creator: Principal,
+}

--- a/src/Mementic_backend/src/nft_module.rs
+++ b/src/Mementic_backend/src/nft_module.rs
@@ -310,6 +310,9 @@ fn init(args: Option<InitArgs>) {
 
     // Initialize sample feedback data (project-specific)
     crate::init_feedback_data();
+
+    crate::rollover::ensure_active_week_initialized();
+    crate::rollover::start_rollover_timer();
 }
 
 fn assert_admin() {

--- a/src/Mementic_backend/src/rollover.rs
+++ b/src/Mementic_backend/src/rollover.rs
@@ -1,0 +1,93 @@
+use crate::index::week_meme_ids;
+use crate::leaderboard::{
+    clear_live_votes, snapshot_weekly_leaderboard, store_weekly_leaderboard, DEFAULT_TOP_N,
+};
+use crate::model::{MemeStatus, WeekId};
+use crate::state::{get_active_week_id, set_active_week_id, MEMES};
+use crate::time::{current_week_id, now_secs};
+use ic_cdk::println;
+use ic_cdk_timers::{clear_timer, set_timer_interval, TimerId};
+use std::cell::RefCell;
+use std::time::Duration;
+
+thread_local! {
+    static TIMER: RefCell<Option<TimerId>> = RefCell::new(None);
+}
+
+pub fn start_rollover_timer() {
+    TIMER.with(|cell| {
+        if let Some(id) = cell.borrow_mut().take() {
+            clear_timer(id);
+        }
+        let id = set_timer_interval(Duration::from_secs(3600), || {
+            maybe_perform_rollover(DEFAULT_TOP_N);
+        });
+        cell.borrow_mut().replace(id);
+    });
+
+    // Perform an immediate check so that deployments catch up to the
+    // correct active week without waiting for the first timer tick.
+    maybe_perform_rollover(DEFAULT_TOP_N);
+}
+
+pub fn maybe_perform_rollover(top_n: usize) -> Option<WeekId> {
+    let current = current_week_id();
+    let active = get_active_week_id();
+
+    if active == 0 {
+        set_active_week_id(current);
+        return None;
+    }
+
+    if current <= active {
+        return None;
+    }
+
+    let finalized_week = active;
+    finalize_week(finalized_week, top_n);
+    set_active_week_id(current);
+
+    println!(
+        "Finalized week {} -> new active week {}",
+        finalized_week, current
+    );
+    Some(finalized_week)
+}
+
+fn finalize_week(week_id: WeekId, top_n: usize) {
+    let finalized_at = now_secs();
+
+    finalize_memes_for_week(week_id, finalized_at);
+
+    if crate::leaderboard::get_weekly_leaderboard(week_id).is_none() {
+        let board = snapshot_weekly_leaderboard(week_id, finalized_at, top_n);
+        store_weekly_leaderboard(board);
+    }
+
+    clear_live_votes();
+}
+
+fn finalize_memes_for_week(week_id: WeekId, finalized_at: u64) {
+    let meme_ids = week_meme_ids(week_id);
+    MEMES.with(|memes| {
+        let mut memes = memes.borrow_mut();
+        for meme_id in meme_ids {
+            if let Some(mut meme) = memes.get(&meme_id) {
+                meme.status = MemeStatus::Finalized;
+                meme.week_ended = true;
+                meme.finalized_at = Some(finalized_at);
+                memes.insert(meme_id, meme);
+            }
+        }
+    });
+}
+
+pub fn admin_rollover_now() -> Option<WeekId> {
+    maybe_perform_rollover(DEFAULT_TOP_N)
+}
+
+pub fn ensure_active_week_initialized() {
+    if get_active_week_id() == 0 {
+        set_active_week_id(current_week_id());
+    }
+}

--- a/src/Mementic_backend/src/state.rs
+++ b/src/Mementic_backend/src/state.rs
@@ -1,0 +1,271 @@
+use crate::model::{Meme, MemeId, WeekId, WeeklyLeaderboard};
+use candid::Principal;
+use ic_stable_structures::cell::StableCell;
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::storable::{Bound, Storable};
+use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::cell::RefCell;
+
+pub type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct StoredU64(pub u64);
+
+impl From<StoredU64> for u64 {
+    fn from(value: StoredU64) -> Self {
+        value.0
+    }
+}
+
+impl From<u64> for StoredU64 {
+    fn from(value: u64) -> Self {
+        StoredU64(value)
+    }
+}
+
+impl Storable for StoredU64 {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 8,
+        is_fixed_size: true,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.0.to_le_bytes().to_vec())
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.0.to_le_bytes().to_vec()
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        if bytes.len() != 8 {
+            return StoredU64(0);
+        }
+        let mut arr = [0u8; 8];
+        arr.copy_from_slice(&bytes);
+        StoredU64(u64::from_le_bytes(arr))
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct StoredI64(pub i64);
+
+impl From<StoredI64> for i64 {
+    fn from(value: StoredI64) -> Self {
+        value.0
+    }
+}
+
+impl From<i64> for StoredI64 {
+    fn from(value: i64) -> Self {
+        StoredI64(value)
+    }
+}
+
+impl Storable for StoredI64 {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 8,
+        is_fixed_size: true,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.0.to_le_bytes().to_vec())
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.0.to_le_bytes().to_vec()
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        if bytes.len() != 8 {
+            return StoredI64(0);
+        }
+        let mut arr = [0u8; 8];
+        arr.copy_from_slice(&bytes);
+        StoredI64(i64::from_le_bytes(arr))
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct MemeIdList(pub Vec<MemeId>);
+
+impl Storable for MemeIdList {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(serde_json::to_vec(&self.0).unwrap_or_default())
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        serde_json::to_vec(&self.0).unwrap_or_default()
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        let vec = serde_json::from_slice(bytes.as_ref()).unwrap_or_default();
+        MemeIdList(vec)
+    }
+}
+
+impl Storable for Meme {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(serde_json::to_vec(self).unwrap_or_default())
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        serde_json::to_vec(&self).unwrap_or_default()
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        serde_json::from_slice(bytes.as_ref()).unwrap_or_else(|_| Meme {
+            id: 0,
+            creator: Principal::anonymous(),
+            image_cid: String::new(),
+            caption: String::new(),
+            created_at: 0,
+            week_id: 0,
+            status: crate::model::MemeStatus::InVoting,
+            week_ended: false,
+            finalized_at: None,
+        })
+    }
+}
+
+impl Storable for WeeklyLeaderboard {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(serde_json::to_vec(self).unwrap_or_default())
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        serde_json::to_vec(&self).unwrap_or_default()
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        serde_json::from_slice(bytes.as_ref()).unwrap_or_else(|_| WeeklyLeaderboard {
+            week_id: 0,
+            finalized_at: 0,
+            top: Vec::new(),
+        })
+    }
+}
+
+thread_local! {
+    pub static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+
+    pub static MEMES: RefCell<StableBTreeMap<MemeId, Meme, Memory>> = RefCell::new(StableBTreeMap::init(
+        MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(60)))
+    ));
+
+    pub static MEMES_BY_WEEK: RefCell<StableBTreeMap<WeekId, MemeIdList, Memory>> = RefCell::new(StableBTreeMap::init(
+        MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(61)))
+    ));
+
+    pub static LIVE_VOTES: RefCell<StableBTreeMap<MemeId, u64, Memory>> = RefCell::new(StableBTreeMap::init(
+        MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(62)))
+    ));
+
+    pub static FINALIZED_LEADERBOARDS: RefCell<StableBTreeMap<WeekId, WeeklyLeaderboard, Memory>> = RefCell::new(StableBTreeMap::init(
+        MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(63)))
+    ));
+
+    static ACTIVE_WEEK_ID_CELL: RefCell<StableCell<StoredU64, Memory>> = RefCell::new(
+        StableCell::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(64))),
+            StoredU64(0)
+        ).expect("initialize ACTIVE_WEEK_ID cell")
+    );
+
+    static NEXT_MEME_ID_CELL: RefCell<StableCell<StoredU64, Memory>> = RefCell::new(
+        StableCell::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(65))),
+            StoredU64(1)
+        ).expect("initialize NEXT_MEME_ID cell")
+    );
+
+    static WEEK_OFFSET_CELL: RefCell<StableCell<StoredI64, Memory>> = RefCell::new(
+        StableCell::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(66))),
+            StoredI64(0)
+        ).expect("initialize WEEK_OFFSET cell")
+    );
+}
+
+pub fn get_active_week_id() -> WeekId {
+    ACTIVE_WEEK_ID_CELL.with(|cell| cell.borrow().get().0)
+}
+
+pub fn set_active_week_id(week_id: WeekId) {
+    ACTIVE_WEEK_ID_CELL.with(|cell| {
+        let mut cell = cell.borrow_mut();
+        let current = cell.get().0;
+        if current != week_id {
+            cell.set(StoredU64(week_id)).expect("set active week id");
+        }
+    });
+}
+
+pub fn get_week_offset() -> i64 {
+    WEEK_OFFSET_CELL.with(|cell| cell.borrow().get().0)
+}
+
+pub fn set_week_offset(offset: i64) {
+    WEEK_OFFSET_CELL.with(|cell| {
+        cell.borrow_mut()
+            .set(StoredI64(offset))
+            .expect("set week offset");
+    });
+}
+
+pub fn next_meme_id() -> MemeId {
+    NEXT_MEME_ID_CELL.with(|cell| {
+        let mut cell = cell.borrow_mut();
+        let current = cell.get().0;
+        let next = current + 1;
+        cell.set(StoredU64(next)).expect("increment meme id");
+        current
+    })
+}
+
+pub fn set_next_meme_id(value: MemeId) {
+    NEXT_MEME_ID_CELL.with(|cell| {
+        cell.borrow_mut()
+            .set(StoredU64(value))
+            .expect("set next meme id");
+    });
+}
+
+pub fn peek_next_meme_id() -> MemeId {
+    NEXT_MEME_ID_CELL.with(|cell| cell.borrow().get().0)
+}
+
+pub fn ensure_next_meme_id_at_least(value: MemeId) {
+    NEXT_MEME_ID_CELL.with(|cell| {
+        let mut cell = cell.borrow_mut();
+        let current = cell.get().0;
+        if current < value {
+            cell.set(StoredU64(value)).expect("ensure next meme id");
+        }
+    });
+}
+
+pub fn with_active_week_id<F, R>(f: F) -> R
+where
+    F: FnOnce(WeekId) -> R,
+{
+    let week = get_active_week_id();
+    f(week)
+}
+
+pub fn with_week_offset<F, R>(f: F) -> R
+where
+    F: FnOnce(i64) -> R,
+{
+    let offset = get_week_offset();
+    f(offset)
+}

--- a/src/Mementic_backend/src/time.rs
+++ b/src/Mementic_backend/src/time.rs
@@ -1,0 +1,26 @@
+use crate::model::WeekId;
+use crate::state;
+
+pub const WEEK_SECONDS: u64 = 604_800;
+
+fn adjust_with_offset(seconds: u64, offset: i64) -> u64 {
+    if offset >= 0 {
+        seconds.saturating_add(offset as u64)
+    } else {
+        seconds.saturating_sub(offset.unsigned_abs())
+    }
+}
+
+pub fn now_secs() -> u64 {
+    ic_cdk::api::time() / 1_000_000_000
+}
+
+pub fn current_week_id() -> WeekId {
+    compute_week_id(now_secs())
+}
+
+pub fn compute_week_id(timestamp_secs: u64) -> WeekId {
+    let offset = state::get_week_offset();
+    let adjusted = adjust_with_offset(timestamp_secs, offset);
+    adjusted / WEEK_SECONDS
+}

--- a/src/Mementic_backend/src/user_profiles.rs
+++ b/src/Mementic_backend/src/user_profiles.rs
@@ -33,7 +33,8 @@ pub struct UserProfile {
 }
 
 impl Storable for UserProfile {
-    const BOUND: ic_stable_structures::storable::Bound = ic_stable_structures::storable::Bound::Unbounded;
+    const BOUND: ic_stable_structures::storable::Bound =
+        ic_stable_structures::storable::Bound::Unbounded;
 
     fn to_bytes(&self) -> Cow<[u8]> {
         use candid::Encode;
@@ -51,7 +52,10 @@ impl Storable for UserProfile {
 }
 
 #[ic_cdk::update]
-pub fn update_user_profile(username: Option<String>, display_name: Option<String>) -> Result<(), String> {
+pub fn update_user_profile(
+    username: Option<String>,
+    display_name: Option<String>,
+) -> Result<(), String> {
     let caller = ic_cdk::caller();
 
     if caller == Principal::anonymous() {
@@ -71,7 +75,10 @@ pub fn update_user_profile(username: Option<String>, display_name: Option<String
             principal: caller,
             username: username.clone(),
             display_name,
-            created_at: existing_profile.as_ref().map(|p| p.created_at).unwrap_or(now),
+            created_at: existing_profile
+                .as_ref()
+                .map(|p| p.created_at)
+                .unwrap_or(now),
             updated_at: now,
         };
 
@@ -90,16 +97,12 @@ pub fn get_user_profile() -> Option<UserProfile> {
 
     let storable_principal = StorablePrincipal::from(caller);
 
-    USER_PROFILES.with(|profiles| {
-        profiles.borrow().get(&storable_principal)
-    })
+    USER_PROFILES.with(|profiles| profiles.borrow().get(&storable_principal))
 }
 
 #[ic_cdk::query]
 pub fn get_user_profile_by_principal(principal: Principal) -> Option<UserProfile> {
     let storable_principal = StorablePrincipal::from(principal);
 
-    USER_PROFILES.with(|profiles| {
-        profiles.borrow().get(&storable_principal)
-    })
+    USER_PROFILES.with(|profiles| profiles.borrow().get(&storable_principal))
 }

--- a/src/Mementic_backend/src/voting.rs
+++ b/src/Mementic_backend/src/voting.rs
@@ -139,7 +139,7 @@ pub enum VoteType {
 
 #[derive(Clone, Debug, Serialize, Deserialize, CandidType)]
 pub struct WeeklyPeriod {
-    pub meme_count: u32,    // optional; not used for logic here
+    pub meme_count: u32, // optional; not used for logic here
     pub week_id: u64,
     pub end_time: u64,      // ns
     pub is_completed: bool, // true once voting is locked for this week
@@ -177,7 +177,7 @@ impl Storable for WeeklyPeriod {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, CandidType)]
-pub struct WeeklyLeaderboard {
+pub struct LegacyWeeklyLeaderboard {
     pub week_id: u64,
     pub period: WeeklyPeriod,
     pub top_memes: Vec<LeaderboardEntry>,
@@ -200,7 +200,7 @@ pub struct TopLikedLeaderboard {
 
 /// Minimal data your NFT canister will need
 #[derive(Clone, Debug, Serialize, Deserialize, CandidType)]
-pub struct TopEntry {
+pub struct LegacyTopEntry {
     pub meme_id: u64,
     pub score: f64,
     pub upvotes: u32,
@@ -315,7 +315,8 @@ fn close_finished_weeks() {
             .filter_map(|entry| {
                 let period = entry.value();
                 // Only finalize weeks that have actually ended and are not the current week
-                if !period.is_completed && period.week_id < current_week_id && now > period.end_time {
+                if !period.is_completed && period.week_id < current_week_id && now > period.end_time
+                {
                     Some(*entry.key())
                 } else {
                     None
@@ -524,9 +525,9 @@ pub fn remove_vote(meme_id: u64) -> Result<VoteResponse, String> {
 
 // ---------- Queries ----------
 
-/// Current weekly leaderboard (active week). Limit max 50.
-#[query]
-pub fn get_current_leaderboard(limit: Option<u32>) -> WeeklyLeaderboard {
+/// Legacy leaderboard query kept for backwards compatibility.
+#[query(name = "get_current_leaderboard_legacy")]
+pub fn get_current_leaderboard_legacy(limit: Option<u32>) -> LegacyWeeklyLeaderboard {
     let now = time();
     let period = get_or_create_current_week();
     let week_id = period.week_id;
@@ -544,7 +545,7 @@ pub fn get_current_leaderboard(limit: Option<u32>) -> WeeklyLeaderboard {
         })
         .collect();
 
-    WeeklyLeaderboard {
+    LegacyWeeklyLeaderboard {
         week_id,
         period: period.clone(),
         top_memes: entries,
@@ -599,7 +600,7 @@ pub fn get_top_liked_memes(limit: Option<u32>) -> TopLikedLeaderboard {
 
 /// Leaderboard for any week id. Returns None if week not found.
 #[query]
-pub fn get_week_leaderboard(week_id: u64, limit: Option<u32>) -> Option<WeeklyLeaderboard> {
+pub fn get_week_leaderboard(week_id: u64, limit: Option<u32>) -> Option<LegacyWeeklyLeaderboard> {
     WEEKLY_PERIODS.with(|wp| {
         let periods = wp.borrow();
         let p = periods.get(&week_id)?;
@@ -617,7 +618,7 @@ pub fn get_week_leaderboard(week_id: u64, limit: Option<u32>) -> Option<WeeklyLe
             })
             .collect();
 
-        Some(WeeklyLeaderboard {
+        Some(LegacyWeeklyLeaderboard {
             week_id,
             period: p,
             top_memes: entries,
@@ -629,7 +630,7 @@ pub fn get_week_leaderboard(week_id: u64, limit: Option<u32>) -> Option<WeeklyLe
 /// Return **Top 3** for a given week (for NFT mint step).
 /// Fails if the week is not completed yet.
 #[query]
-pub fn get_top3_for_week(week_id: u64) -> Result<Vec<TopEntry>, String> {
+pub fn get_top3_for_week(week_id: u64) -> Result<Vec<LegacyTopEntry>, String> {
     // Ensure no active voting and week exists
     let p = WEEKLY_PERIODS.with(|wp| wp.borrow().get(&week_id));
     let period = p.ok_or_else(|| "Week not found".to_string())?;
@@ -671,7 +672,7 @@ pub fn get_top3_for_week(week_id: u64) -> Result<Vec<TopEntry>, String> {
 
     let out = items
         .into_iter()
-        .map(|(meme_id, mv)| TopEntry {
+        .map(|(meme_id, mv)| LegacyTopEntry {
             meme_id,
             score: mv.score, // kept for reference/telemetry, not used for ranking here
             upvotes: mv.upvotes,
@@ -831,7 +832,11 @@ pub fn force_finalize_current_week() -> Result<String, String> {
     let winners = match get_top3_for_week(period.week_id) {
         Ok(top) => top,
         Err(e) => {
-            ic_cdk::println!("Week {} finalized without leaderboard data: {}", period.week_id, e);
+            ic_cdk::println!(
+                "Week {} finalized without leaderboard data: {}",
+                period.week_id,
+                e
+            );
             Vec::new()
         }
     };
@@ -846,7 +851,11 @@ pub fn force_finalize_current_week() -> Result<String, String> {
     // Clean up old memes and voting data from previous weeks
     cleanup_old_week_data(period.week_id)?;
 
-    Ok(format!("Week {} force-finalized with {} winners", period.week_id, winners.len()))
+    Ok(format!(
+        "Week {} force-finalized with {} winners",
+        period.week_id,
+        winners.len()
+    ))
 }
 
 /// Force-complete a specific week_id (admin/ops hook).
@@ -1022,11 +1031,21 @@ pub fn sync_week_state() -> String {
     let period = get_or_create_current_week();
 
     if period.is_completed {
-        format!("Week {} is completed. Next active week should be available.", period.week_id)
+        format!(
+            "Week {} is completed. Next active week should be available.",
+            period.week_id
+        )
     } else if now > period.end_time {
-        format!("Week {} has ended but not yet finalized. Next active week should be available.", period.week_id)
+        format!(
+            "Week {} has ended but not yet finalized. Next active week should be available.",
+            period.week_id
+        )
     } else {
-        format!("Week {} is active. {} remaining.", period.week_id, format_remaining_time(period.end_time - now))
+        format!(
+            "Week {} is active. {} remaining.",
+            period.week_id,
+            format_remaining_time(period.end_time - now)
+        )
     }
 }
 

--- a/src/Mementic_frontend/src/hooks/useMarketplaceData.js
+++ b/src/Mementic_frontend/src/hooks/useMarketplaceData.js
@@ -6,6 +6,7 @@ import {
   toOptionalBigInt,
   normalizeMeme,
   deriveWeekIdFromMs,
+  PAGE_SIZE,
 } from "../utils/marketplaceUtils";
 
 export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, searchQuery) => {
@@ -103,21 +104,55 @@ export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, 
       setLoadingTop(true);
       setErrorMsg("");
       try {
-        const res = await backendService.getTopLikedMemes(3);
-        const entries = ensureArray(res?.top_memes ?? res);
+        const leaderboard = await backendService.getCurrentLeaderboard(0, 50);
+        const entries = ensureArray(leaderboard);
 
-        // Get unique owners for profile fetching
-        const uniqueOwners = [...new Set(entries.map(e => {
-          const owner = e?.owner;
-          if (owner) {
-            if (typeof owner === "string") return owner;
-            if (typeof owner === "object" && owner.toText) return owner.toText();
-            return String(owner);
-          }
-          return null;
-        }).filter(Boolean))];
+        if (entries.length === 0) {
+          if (!cancelled) setTopMemes([]);
+          return;
+        }
 
-        // Fetch user profiles for leaderboard owners
+        const resolved = await Promise.all(
+          entries.map(async (entry) => {
+            const rawId = Array.isArray(entry?.meme_id)
+              ? entry.meme_id[0]
+              : entry?.meme_id;
+            const memeId = safeBigIntToNumber(rawId);
+            if (!Number.isFinite(memeId) || memeId <= 0) {
+              return null;
+            }
+            try {
+              const meme = await backendService.getMeme(memeId);
+              return meme ? { entry, meme } : null;
+            } catch (error) {
+              console.warn(`Failed to fetch meme ${memeId} for leaderboard:`, error);
+              return null;
+            }
+          })
+        );
+
+        const valid = resolved.filter(Boolean);
+        if (valid.length === 0) {
+          if (!cancelled) setTopMemes([]);
+          return;
+        }
+
+        const uniqueOwners = [
+          ...new Set(
+            valid
+              .map(({ meme }) => {
+                const owner = meme?.owner ?? meme?.meme_data?.owner ?? meme?.creator;
+                if (owner) {
+                  if (typeof owner === "string") return owner;
+                  if (typeof owner === "object" && owner.toText) return owner.toText();
+                  return String(owner);
+                }
+                return null;
+              })
+              .filter(Boolean)
+          ),
+        ];
+
         const userProfiles = new Map();
         for (const principal of uniqueOwners) {
           try {
@@ -130,41 +165,29 @@ export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, 
           }
         }
 
-        const arr = entries.map((e) => {
-          const pm = Array.isArray(e?.meme_data)
-            ? e.meme_data[0]
-            : e?.meme_data;
-          const normalized = pm
-            ? normalizeMeme(pm, { rank: e?.rank, votes: e?.votes }, userProfiles)
-            : normalizeMeme(
-                {
-                  id: e?.meme_id,
-                  title: `Meme #${e?.meme_id ?? "?"}`,
-                  owner: e?.owner,
-                  meme_data: e?.meme_data,
-                },
-                { rank: e?.rank, votes: e?.votes },
-                userProfiles
-              );
-
-          const likeCount = safeBigIntToNumber(e?.votes?.upvotes ?? normalized.votes ?? 0);
-          const downvoteCount = safeBigIntToNumber(e?.votes?.downvotes ?? 0);
+        const arr = valid.map(({ entry, meme }) => {
+          const upvotes = safeBigIntToNumber(entry?.votes ?? entry?.votes?.upvotes ?? 0);
+          const normalized = normalizeMeme(
+            meme,
+            { rank: entry?.rank, votes: { upvotes } },
+            userProfiles
+          );
 
           return {
             ...normalized,
-            votes: likeCount,
-            likeCount,
-            downvoteCount,
-            voteScore: normalized.votes,
-            voteDetails: e?.votes ?? null,
+            votes: upvotes,
+            likeCount: upvotes,
+            downvoteCount: 0,
+            voteScore: upvotes,
+            voteDetails: { upvotes, downvotes: 0 },
           };
         });
+
         const filtered =
           currentWeekId == null
             ? arr
             : arr.filter((meme) => {
                 const week = deriveWeekIdFromMs(meme?.created_at);
-                // Exclude memes from previous week specifically
                 if (week !== null && previousWeekId !== null && week === previousWeekId) {
                   return false;
                 }
@@ -207,133 +230,76 @@ export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, 
     setLoadingList(true);
     setErrorMsg("");
     try {
-      let arr = [];
-      let userProfiles = new Map();
+      const pageSize = PAGE_SIZE;
+      const offset = (page - 1) * pageSize;
+      const cards = await backendService.listPremarketMemes(offset, pageSize);
+      const entries = ensureArray(cards);
 
-      try {
-        // Try to get all memes first
-        const rawAll = await backendService.getAllMemes();
-        const rawMemes = ensureArray(rawAll);
-
-        // Get unique owners for profile fetching
-        const uniqueOwners = [...new Set(rawMemes.map(m => {
-          const owner = m?.owner ?? m?.meme_data?.owner ?? m?.creator;
-          if (owner) {
-            if (typeof owner === "string") return owner;
-            if (typeof owner === "object" && owner.toText) return owner.toText();
-            return String(owner);
-          }
-          return null;
-        }).filter(Boolean))];
-
-        // Fetch user profiles for all owners
-        for (const principal of uniqueOwners) {
-          try {
-            const profile = await backendService.getUserProfileByPrincipal(principal);
-            if (profile) {
-              userProfiles.set(principal, profile);
-            }
-          } catch (error) {
-            console.warn(`Failed to fetch profile for ${principal}:`, error);
-          }
+      if (entries.length === 0) {
+        if (reset || page === 1) {
+          setMemes([]);
         }
+        setTotal(offset);
+        setLoadingList(false);
+        return;
+      }
 
-        arr = rawMemes.map((m) => normalizeMeme(m, {}, userProfiles));
-      } catch (err) {
-        console.warn("getAllMemes failed, trying getMarketplaceMemes:", err);
-        try {
-          const rawMarketplace = await backendService.getMarketplaceMemes();
-          const rawMemes = ensureArray(rawMarketplace);
-
-          // Get unique owners for profile fetching
-          const uniqueOwners = [...new Set(rawMemes.map(m => {
-            const owner = m?.owner ?? m?.meme_data?.owner ?? m?.creator;
-            if (owner) {
-              if (typeof owner === "string") return owner;
-              if (typeof owner === "object" && owner.toText) return owner.toText();
-              return String(owner);
-            }
+      const resolved = await Promise.all(
+        entries.map(async (card) => {
+          const rawId = Array.isArray(card?.id) ? card.id[0] : card?.id;
+          const memeId = safeBigIntToNumber(rawId);
+          if (!Number.isFinite(memeId) || memeId <= 0) {
             return null;
-          }).filter(Boolean))];
-
-          // Fetch user profiles for all owners
-          for (const principal of uniqueOwners) {
-            try {
-              const profile = await backendService.getUserProfileByPrincipal(principal);
-              if (profile) {
-                userProfiles.set(principal, profile);
-              }
-            } catch (error) {
-              console.warn(`Failed to fetch profile for ${principal}:`, error);
-            }
           }
-
-          arr = rawMemes.map((m) => normalizeMeme(m, {}, userProfiles));
-        } catch (err2) {
-          console.warn(
-            "getMarketplaceMemes failed, trying getUserMemes:",
-            err2
-          );
           try {
-            const rawUser = await backendService.getUserMemes();
-            const rawMemes = ensureArray(rawUser);
+            const detail = await backendService.getMeme(memeId);
+            return detail ? { detail } : null;
+          } catch (error) {
+            console.warn(`Failed to fetch meme ${memeId}:`, error);
+            return null;
+          }
+        })
+      );
 
-            // Get unique owners for profile fetching
-            const uniqueOwners = [...new Set(rawMemes.map(m => {
-              const owner = m?.owner ?? m?.meme_data?.owner ?? m?.creator;
+      const valid = resolved.filter(Boolean);
+      if (valid.length === 0) {
+        if (reset || page === 1) {
+          setMemes([]);
+        }
+        setTotal(offset);
+        setLoadingList(false);
+        return;
+      }
+
+      const uniqueOwners = [
+        ...new Set(
+          valid
+            .map(({ detail }) => {
+              const owner = detail?.owner ?? detail?.meme_data?.owner ?? detail?.creator;
               if (owner) {
                 if (typeof owner === "string") return owner;
                 if (typeof owner === "object" && owner.toText) return owner.toText();
                 return String(owner);
               }
               return null;
-            }).filter(Boolean))];
+            })
+            .filter(Boolean)
+        ),
+      ];
 
-            // Fetch user profiles for all owners
-            for (const principal of uniqueOwners) {
-              try {
-                const profile = await backendService.getUserProfileByPrincipal(principal);
-                if (profile) {
-                  userProfiles.set(principal, profile);
-                }
-              } catch (error) {
-                console.warn(`Failed to fetch profile for ${principal}:`, error);
-              }
-            }
-
-            arr = rawMemes.map((m) => normalizeMeme(m, {}, userProfiles));
-          } catch (err3) {
-            console.warn("All meme fetching methods failed:", err3);
-            // Sample data fallback
-            arr = [
-              normalizeMeme({
-                id: "sample-1",
-                title: "Sample Meme 1",
-                prompt: "A funny sample meme",
-                caption: "Sample Meme 1",
-                owner: "SampleUser",
-                image_url: "",
-                votes: 5,
-                views: 10,
-                created_at: Date.now(),
-                emoji: "😂",
-              }, {}, userProfiles),
-              normalizeMeme({
-                id: "sample-2",
-                title: "Sample Meme 2",
-                prompt: "Another sample meme",
-                caption: "Sample Meme 2",
-                owner: "SampleUser2",
-                image_url: "",
-                votes: 3,
-                views: 8,
-                created_at: Date.now() - 86400000,
-                emoji: "🤣",
-              }, {}, userProfiles),
-            ];
+      const userProfiles = new Map();
+      for (const principal of uniqueOwners) {
+        try {
+          const profile = await backendService.getUserProfileByPrincipal(principal);
+          if (profile) {
+            userProfiles.set(principal, profile);
           }
+        } catch (error) {
+          console.warn(`Failed to fetch profile for ${principal}:`, error);
         }
       }
+
+      const arr = valid.map(({ detail }) => normalizeMeme(detail, {}, userProfiles));
 
       const getCreatedAt = (meme) => safeBigIntToNumber(meme?.created_at || 0);
       const getVotes = (meme) => safeBigIntToNumber(meme?.votes || 0);
@@ -370,33 +336,29 @@ export const useMarketplaceData = (isAuthenticated, hasProfileName, page, sort, 
         });
       }
 
-      // Filter to current week only (exclude previous week memes)
       const filteredByWeek =
         currentWeekId == null
           ? arr
           : arr.filter((meme) => {
               const week = deriveWeekIdFromMs(meme?.created_at);
-              // Exclude memes from previous week specifically
               if (week !== null && previousWeekId !== null && week === previousWeekId) {
                 return false;
               }
               return week == null || week === currentWeekId;
             });
 
-      const filteredForListing = filteredByWeek.filter((meme) => {
-        const sale = meme?.sale_metadata ?? meme?.market_data ?? {};
-        const isListed = Boolean(sale?.is_listed ?? sale?.isListed);
-        return !isListed;
-      });
+        const filteredForListing = filteredByWeek.filter((meme) => {
+          const sale = meme?.sale_metadata ?? meme?.market_data ?? {};
+          const isListed = Boolean(sale?.is_listed ?? sale?.isListed);
+          return !isListed;
+        });
 
-      // Client-side paging
-      const start = (page - 1) * 12; // PAGE_SIZE = 12
-      const slice = filteredForListing.slice(start, start + 12);
+        const slice = filteredForListing;
 
-      setTotal(filteredForListing.length);
-      setMemes((prev) =>
-        page === 1 || reset ? slice : [...ensureArray(prev), ...slice]
-      );
+        setTotal(offset + filteredForListing.length);
+        setMemes((prev) =>
+          page === 1 || reset ? filteredForListing : [...ensureArray(prev), ...filteredForListing]
+        );
 
       // Refresh vote counts for newly loaded memes
       if (slice.length > 0) {

--- a/src/Mementic_frontend/src/services/backendService.js
+++ b/src/Mementic_frontend/src/services/backendService.js
@@ -494,11 +494,43 @@ class BackendService {
   }
 
   /**
-   * Get current leaderboard
+   * List pre-market memes for the current active week with pagination
    */
-  async getCurrentLeaderboard(limit = 50) {
-    const limitOpt = typeof limit === "number" ? [limit] : [];
-    return await this._safeCall('get_current_leaderboard', limitOpt);
+  async listPremarketMemes(offset = 0, limit = 12) {
+    const result = await this._safeCall('list_premarket_memes', offset, limit);
+    return Array.isArray(result) ? result : [];
+  }
+
+  /**
+   * Get current weekly leaderboard snapshot with pagination
+   */
+  async getCurrentLeaderboard(offsetOrLimit = 0, maybeLimit = 50) {
+    let offset = 0;
+    let limit = 50;
+    if (typeof offsetOrLimit === "number" && typeof maybeLimit === "number") {
+      offset = offsetOrLimit;
+      limit = maybeLimit;
+    } else if (typeof offsetOrLimit === "number") {
+      limit = offsetOrLimit;
+    }
+    const result = await this._safeCall('get_current_leaderboard', offset, limit);
+    return Array.isArray(result) ? result : [];
+  }
+
+  /**
+   * Retrieve a finalized leaderboard snapshot for a specific week
+   */
+  async getLeaderboardByWeek(weekId) {
+    const result = await this._safeCall('get_leaderboard_by_week', weekId);
+    return this._fromOpt(result);
+  }
+
+  /**
+   * List archived weeks with finalized leaderboards
+   */
+  async listFinalizedWeeks(offset = 0, limit = 10) {
+    const result = await this._safeCall('list_finalized_weeks', offset, limit);
+    return Array.isArray(result) ? result : [];
   }
 
   /**


### PR DESCRIPTION
## Summary
- add stable weekly storage, time helpers, and leaderboard snapshot logic for meme rollovers
- integrate rollover checks with meme creation/publishing, expose new query/update endpoints, and update the Candid interface and docs
- update the frontend service and marketplace hook to consume the new paginated weekly APIs
- ensure the rollover timer performs an immediate catch-up when armed so the active week advances as soon as a week ends

## Testing
- `cargo fmt`
- `cargo check` *(fails: crates.io index returned 403 during download)*

------
https://chatgpt.com/codex/tasks/task_e_68f3e93b8324832ba349e74f29d8c6c1