### PR TITLE
Add weekly voting power enforcement to meme voting

### DIFF
--- a/src/Mementic_backend/Mementic_backend.did
+++ b/src/Mementic_backend/Mementic_backend.did
@@ -315,5 +315,8 @@ service : (opt InitArgs) -> {
   // Cast or change a vote on a meme in the **current active week**.
   // Rejects if meme is not from current week or if the week is completed/expired.
   vote_meme : (nat64, VoteType) -> (Result_6);
+  // Cast a vote while explicitly specifying the voting power cost.
+  // Enforces the weekly voting power cap and deducts the provided cost from the caller.
+  vote_with_power : (nat64, VoteType, nat32) -> (Result_6);
   whoami : () -> (principal) query;
 }

--- a/src/Mementic_backend/src/lib.rs
+++ b/src/Mementic_backend/src/lib.rs
@@ -52,9 +52,9 @@ pub use http_outcall::{
 pub use voting::{
     finalize_finished_weeks, finalize_week, get_completed_weeks, get_current_week_status,
     get_meme_votes, get_top3_for_week, get_top_liked_memes, get_user_vote, get_voting_stats,
-    get_week_leaderboard, remove_vote, vote_meme,
-    LeaderboardEntry, LegacyTopEntry, LegacyWeeklyLeaderboard, MemeVotes, TopLikedLeaderboard, 
-    VoteRecord, VoteResponse, VoteType, WeeklyPeriod, UserPower,
+    get_week_leaderboard, remove_vote, vote_meme, vote_with_power, LeaderboardEntry,
+    LegacyTopEntry, LegacyWeeklyLeaderboard, MemeVotes, TopLikedLeaderboard, UserPower, VoteRecord,
+    VoteResponse, VoteType, WeeklyPeriod,
 };
 
 pub use entitlements::{

--- a/src/Mementic_backend/src/voting.rs
+++ b/src/Mementic_backend/src/voting.rs
@@ -236,10 +236,18 @@ pub struct UserPower {
 impl Storable for UserPower {
     const BOUND: Bound = Bound::Unbounded;
 
-    fn to_bytes(&self) -> Cow<[u8]> { Cow::Owned(Encode!(&self).expect("encode UserPower")) }
-    fn into_bytes(self) -> Vec<u8> { Encode!(&self).expect("encode UserPower") }
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(Encode!(&self).expect("encode UserPower"))
+    }
+    fn into_bytes(self) -> Vec<u8> {
+        Encode!(&self).expect("encode UserPower")
+    }
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        Decode!(&bytes, UserPower).unwrap_or(UserPower { week_id: 0, remaining: WEEKLY_POWER_CAP, cap: WEEKLY_POWER_CAP })
+        Decode!(&bytes, UserPower).unwrap_or(UserPower {
+            week_id: 0,
+            remaining: WEEKLY_POWER_CAP,
+            cap: WEEKLY_POWER_CAP,
+        })
     }
 }
 
@@ -298,7 +306,11 @@ fn get_or_reset_user_power(user: Principal, week_id: u64) -> UserPower {
             }
             p
         } else {
-            let p = UserPower { week_id, remaining: WEEKLY_POWER_CAP, cap: WEEKLY_POWER_CAP };
+            let p = UserPower {
+                week_id,
+                remaining: WEEKLY_POWER_CAP,
+                cap: WEEKLY_POWER_CAP,
+            };
             map.insert(user, p.clone());
             p
         }
@@ -309,9 +321,11 @@ fn get_or_reset_user_power(user: Principal, week_id: u64) -> UserPower {
 fn spend_power(user: Principal, week_id: u64, cost: u32) -> Result<(), String> {
     USER_POWERS.with(|up| {
         let mut map = up.borrow_mut();
-        let mut p = map
-            .get(&user)
-            .unwrap_or(UserPower { week_id, remaining: WEEKLY_POWER_CAP, cap: WEEKLY_POWER_CAP });
+        let mut p = map.get(&user).unwrap_or(UserPower {
+            week_id,
+            remaining: WEEKLY_POWER_CAP,
+            cap: WEEKLY_POWER_CAP,
+        });
         if p.week_id != week_id {
             p.week_id = week_id;
             p.remaining = WEEKLY_POWER_CAP;
@@ -411,69 +425,61 @@ fn close_finished_weeks() {
 
 /// Cast or change a vote on a meme in the **current active week**.
 /// Rejects if meme is not from current week or if the week is completed/expired.
-#[update]
-pub fn vote_meme(meme_id: u64, vote_type: VoteType) -> Result<VoteResponse, String> {
-    let user = caller();
-    ic_cdk::println!("Vote meme - Caller principal: {}", user.to_text());
+fn perform_vote(
+    user: Principal,
+    meme_id: u64,
+    vote_type: VoteType,
+    cost: u32,
+) -> Result<VoteResponse, String> {
+    ic_cdk::println!(
+        "Processing vote - Caller: {}, Meme: {}, Cost: {}",
+        user.to_text(),
+        meme_id,
+        cost
+    );
 
     if user == Principal::anonymous() {
-        ic_cdk::println!("Vote meme - Anonymous user detected, rejecting request");
         return Err("Authentication required".into());
     }
-
-    ic_cdk::println!("Vote meme - Authenticated user: {}", user.to_text());
-    let now = time();
-
-    // Input validation
     if meme_id == 0 {
         return Err("Invalid meme ID".into());
     }
+    if cost == 0 {
+        return Err("Voting cost must be greater than zero".into());
+    }
+    if cost > WEEKLY_POWER_CAP {
+        return Err("Voting cost exceeds weekly cap".into());
+    }
 
-    // Ensure week periods are up to date and there's always an active week
+    let now = time();
+
     close_finished_weeks();
     ensure_active_week();
 
-    // Validate meme exists
     let meme = get_meme(meme_id).ok_or("Meme not found")?;
-
-    // Prevent self-voting: check if caller is the meme owner
     if meme.owner == user {
         return Err("Cannot vote on your own meme".into());
     }
 
-    // Determine meme's week and current week
     let meme_week = get_week_id(meme.created_at);
     let period = get_or_create_current_week();
     let current_week = period.week_id;
 
-    // Only allow votes for memes created this week
     if meme_week != current_week {
         return Err("Can only vote on memes from the current week".into());
     }
-    // Block voting if the week is completed or time passed
     if period.is_completed || now > period.end_time {
         return Err("Voting period for the current week has ended".into());
     }
 
-    // Enforce weekly voting power before recording a fresh vote
-    let _ = ensure_active_week();
-    let current_week = get_current_week_id();
-
-    // Prevent multiple votes per meme (legacy behavior) and then charge for first vote
-    // Track previous vote
     let key = UserMemeKey(user, meme_id);
     let previous_vote = USER_VOTES.with(|uv| uv.borrow().get(&key));
-
-    // Prevent multiple votes per user per meme
     if previous_vote.is_some() {
         return Err("You have already voted on this meme".into());
     }
 
-    // Spend voting power (default cost)
-    let cost = DEFAULT_VOTE_COST;
     spend_power(user, current_week, cost)?;
 
-    // Update user's vote record
     USER_VOTES.with(|uv| {
         uv.borrow_mut().insert(
             key,
@@ -484,7 +490,6 @@ pub fn vote_meme(meme_id: u64, vote_type: VoteType) -> Result<VoteResponse, Stri
         );
     });
 
-    // Update aggregates
     VOTES.with(|v| {
         let mut map = v.borrow_mut();
         let mut mv = map.get(&meme_id).unwrap_or(MemeVotes {
@@ -497,7 +502,6 @@ pub fn vote_meme(meme_id: u64, vote_type: VoteType) -> Result<VoteResponse, Stri
             last_vote_time: now,
         });
 
-        // undo previous vote (if switching)
         if let Some(prev) = &previous_vote {
             match prev.vote_type {
                 VoteType::Upvote => mv.upvotes = mv.upvotes.saturating_sub(1),
@@ -507,21 +511,17 @@ pub fn vote_meme(meme_id: u64, vote_type: VoteType) -> Result<VoteResponse, Stri
             mv.total_voters = mv.total_voters.saturating_add(1);
         }
 
-        // apply new
         match vote_type {
             VoteType::Upvote => mv.upvotes = mv.upvotes.saturating_add(1),
             VoteType::Downvote => mv.downvotes = mv.downvotes.saturating_add(1),
         }
 
-        // recompute score
         let age_hours = (now - meme.created_at) as f64 / 1_000_000_000.0 / 3600.0;
         mv.score = calculate_score(mv.upvotes, mv.downvotes, age_hours);
         mv.last_vote_time = now;
 
         map.insert(meme_id, mv.clone());
 
-        // Keep LIVE_VOTES (used by current_week leaderboard) in sync with upvotes
-        // so the frontend leaderboard reflects changes immediately.
         crate::leaderboard::set_vote_count(meme_id, mv.upvotes as u64);
 
         Ok(VoteResponse {
@@ -531,6 +531,29 @@ pub fn vote_meme(meme_id: u64, vote_type: VoteType) -> Result<VoteResponse, Stri
             user_previous_vote: previous_vote.map(|v| v.vote_type),
         })
     })
+}
+
+#[update]
+pub fn vote_meme(meme_id: u64, vote_type: VoteType) -> Result<VoteResponse, String> {
+    let user = caller();
+    perform_vote(user, meme_id, vote_type, DEFAULT_VOTE_COST)
+}
+
+#[update]
+pub fn vote_with_power(
+    meme_id: u64,
+    vote_type: VoteType,
+    cost: u32,
+) -> Result<VoteResponse, String> {
+    let user = caller();
+    let charge = if cost == 0 {
+        DEFAULT_VOTE_COST
+    } else if cost > WEEKLY_POWER_CAP {
+        return Err("Voting cost exceeds weekly cap".into());
+    } else {
+        cost
+    };
+    perform_vote(user, meme_id, vote_type, charge)
 }
 
 /// Remove your vote (works only for current active week)
@@ -615,8 +638,6 @@ pub fn remove_vote(meme_id: u64) -> Result<VoteResponse, String> {
 }
 
 // ---------- Queries ----------
-
- 
 
 /// Legacy leaderboard query kept for backwards compatibility.
 #[query(name = "get_current_leaderboard_legacy")]
@@ -965,7 +986,9 @@ pub fn force_finalize_current_week() -> Result<String, String> {
         })
         .collect();
 
-    if let Err(err) = crate::entitlements::create_entitlements_for_week(period.week_id, &top_entries) {
+    if let Err(err) =
+        crate::entitlements::create_entitlements_for_week(period.week_id, &top_entries)
+    {
         return Err(format!(
             "Failed to issue mint entitlements for week {}: {}",
             period.week_id, err
@@ -985,7 +1008,7 @@ pub fn force_finalize_current_week() -> Result<String, String> {
     // Advance to the next week so new memes can be created
     let next_week_id = period.week_id + 1;
     crate::state::set_active_week_id(next_week_id);
-    
+
     // Create the next week period to ensure voting is ready
     WEEKLY_PERIODS.with(|wp| {
         let mut periods = wp.borrow_mut();
@@ -1005,9 +1028,7 @@ pub fn force_finalize_current_week() -> Result<String, String> {
 
     Ok(format!(
         "Week {} force-finalized with {} winners. Advanced to week {}",
-        period.week_id,
-        winners_len,
-        next_week_id
+        period.week_id, winners_len, next_week_id
     ))
 }
 

--- a/src/Mementic_frontend/src/hooks/useVotingPower.js
+++ b/src/Mementic_frontend/src/hooks/useVotingPower.js
@@ -8,10 +8,11 @@ import backendService from "../services/backendService";
  * - Auto-refreshes on mount and when week changes.
  */
 export default function useVotingPower() {
-  const WEEKLY_CAP = 100;
+  const DEFAULT_WEEKLY_CAP = 100;
   const VOTE_COST = 10;
 
-  const [power, setPower] = useState(WEEKLY_CAP);
+  const [cap, setCap] = useState(DEFAULT_WEEKLY_CAP);
+  const [power, setPower] = useState(DEFAULT_WEEKLY_CAP);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [weekId, setWeekId] = useState(null);
@@ -26,12 +27,18 @@ export default function useVotingPower() {
       }
       const res = await backendService.getVotingPower();
       if (typeof res === "number" && Number.isFinite(res)) {
+        setCap(DEFAULT_WEEKLY_CAP);
         setPower(res);
-      } else if (res && typeof res.remaining === "number") {
-        setPower(res.remaining);
+      } else if (res && typeof res === "object") {
+        const nextCap = Number(res.cap);
+        const safeCap = Number.isFinite(nextCap) && nextCap > 0 ? nextCap : DEFAULT_WEEKLY_CAP;
+        const nextRemaining = Number(res.remaining);
+        const safeRemaining = Number.isFinite(nextRemaining) ? nextRemaining : safeCap;
+        setCap(safeCap);
+        setPower(Math.min(safeCap, safeRemaining));
       } else {
-        // Fallback if backend not yet implemented: assume full power
-        setPower(WEEKLY_CAP);
+        setCap(DEFAULT_WEEKLY_CAP);
+        setPower(DEFAULT_WEEKLY_CAP);
       }
     } catch (e) {
       setError(e?.message || "Failed to load voting power");
@@ -72,16 +79,19 @@ export default function useVotingPower() {
     setPower((p) => Math.max(0, p - amount));
   }, []);
 
-  const refund = useCallback((amount = VOTE_COST) => {
-    setPower((p) => Math.min(WEEKLY_CAP, p + amount));
-  }, []);
+  const refund = useCallback(
+    (amount = VOTE_COST) => {
+      setPower((p) => Math.min(cap, p + amount));
+    },
+    [cap]
+  );
 
   return {
     power,
     weekId,
     loading,
     error,
-    WEEKLY_CAP,
+    WEEKLY_CAP: cap,
     VOTE_COST,
     canAfford,
     refresh,

--- a/src/Mementic_frontend/src/services/backendService.js
+++ b/src/Mementic_frontend/src/services/backendService.js
@@ -616,22 +616,47 @@ class BackendService {
    * Graceful fallback to 100 if backend method not available.
    */
   async getVotingPower() {
+    const fallback = { remaining: 100, cap: 100 };
+    const toNumber = (value, defaultValue) => {
+      if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : defaultValue;
+      }
+      if (typeof value === 'bigint') {
+        const max = BigInt(Number.MAX_SAFE_INTEGER);
+        const bounded = value < BigInt(0) ? BigInt(0) : value > max ? max : value;
+        return Number(bounded);
+      }
+      if (Array.isArray(value) && value.length > 0) {
+        return toNumber(value[0], defaultValue);
+      }
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : defaultValue;
+    };
+
     try {
       if (!this.actor || typeof this.actor['get_voting_power'] !== 'function') {
-        // Fallback default until backend is updated
-        return 100;
+        return fallback;
       }
+
       const res = await this._safeCall('get_voting_power');
-      // Support either number or { remaining: nat, cap: nat }
-      if (typeof res === 'number') return res;
-      if (res && typeof res === 'object') {
-        const remaining = Array.isArray(res.remaining) ? res.remaining[0] : res.remaining;
-        return Number(remaining ?? 100);
+
+      if (typeof res === 'number') {
+        return { ...fallback, remaining: toNumber(res, fallback.remaining) };
       }
-      return 100;
+
+      if (res && typeof res === 'object') {
+        const remaining = toNumber(res.remaining, fallback.remaining);
+        const cap = toNumber(res.cap, fallback.cap);
+        return {
+          remaining: Number.isFinite(remaining) ? remaining : fallback.remaining,
+          cap: Number.isFinite(cap) && cap > 0 ? cap : fallback.cap,
+        };
+      }
+
+      return fallback;
     } catch (e) {
       console.warn('get_voting_power failed, using default 100:', e);
-      return 100;
+      return fallback;
     }
   }
 
@@ -644,9 +669,15 @@ class BackendService {
       throw new Error("Authentication required: Please login to vote on memes");
     }
     const voteVariant = this._toVoteVariant(voteType);
+    const normalizedCost = Math.max(1, Math.floor(Number(cost) || 0));
     try {
       if (this.actor && typeof this.actor['vote_with_power'] === 'function') {
-        const result = await this._safeCall('vote_with_power', memeId, voteVariant, BigInt(cost));
+        const result = await this._safeCall(
+          'vote_with_power',
+          memeId,
+          voteVariant,
+          BigInt(normalizedCost)
+        );
         return this._unwrapResult(result, 'vote_with_power failed');
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- enforce voting power spend on every vote through a shared backend helper and expose a configurable `vote_with_power` endpoint
- surface the new endpoint in the candid interface and service layer while normalizing voting power responses for the UI
- refresh the frontend voting power hook to track weekly caps and deduct power locally after each vote

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f617243f68832b8602f99b0862bf86